### PR TITLE
add gitbook link to docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,37 @@
+# Contributing
+
+By participating in this project, you agree to abide by the thoughtbot [code of conduct].
+
+[code of conduct]: https://thoughtbot.com/open-source-code-of-conduct
+
+Fork, then clone the repo:
+
+    git clone git@github.com/wellcometrust/platform.git
+
+Make your change. Write a test for your change, (or the other way round).
+
+Push to your fork and [submit a pull request][pr].
+
+[pr]: https://github.com/wellcometrust/platform/compare/
+
+At this point you're waiting on us. We like to at least comment on pull requests
+within three business days. We may suggest some changes or improvements or alternatives.
+
+Some things that will increase the chance that your pull request is accepted:
+
+- Ensure you appropriately lint any changes using the relevant `make` tasks.
+- Write a [good commit message][commit].
+
+[commit]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
+
+## Pull Request process
+
+Here are some guidelines that we follow internally when submitting PRs:
+
+- Open PRs as early as possible to provide visibility of work
+- PRs not ready for final review should be prefixed "[WIP]"
+- Developers should assign themselves to PRs they have contributed code changes to
+- PRs should only be approved by someone who has not contributed code changes
+- PRs should be merged by the assignees of a PR
+- RFC PRs should be approved by all non-contributing developers in the digital platform team in order to be merged
+- Developers assigned to a PR are responsible for deploying their changes after a merge

--- a/README.md
+++ b/README.md
@@ -2,8 +2,15 @@
 
 This is documentation for Wellcome Collection developers. Documentation for users of the API can be found at https://developers.wellcomecollection.org.
 
+- [Projects](projects/README.md): A list of projects and services supported by Wellcome Collection developers.
+- [Process](process.md): How we work.
+- [RFCs](rfcs): A collection of RFCs for Wellcome Collection developers.
 
-* [Projects](projects/README.md): A list of projects and services supported by Wellcome Collection developers.
-* [Process](process.md): How we work.
-* [RFCs](rfcs): A collection of RFCs for Wellcome Collection developers.
+## Contributing
 
+This doucmentation is held in our [GitHub][github repo], and also made more discoverable hosting it in [GitBook][gitbook].
+
+You can either edit the documentation
+
+[gitbook]: https://docs.wellcomecollection.org/developers
+[github repo]: https://github.com/wellcomecollection/docs


### PR DESCRIPTION
To allow us to read and browse the documentation better, we render it through gitbook