### PR TITLE
Add Platform Reliability RFC

### DIFF
--- a/rfcs/019-platform_reliability/README.md
+++ b/rfcs/019-platform_reliability/README.md
@@ -1,0 +1,15 @@
+## Platform Reliability
+
+**Status:** :building_construction: Draft :construction:
+
+**Last updated:** 2020/02/04
+
+### Overview / background
+
+Following on from a review of current reliability issues, here is aggregated what was discussed into some proposals for action.
+
+The discussion split into 3 major areas:
+
+- [Continuous Integration / Continuous deployment](ci_cd.md) : Handling automated testing & deployment.
+- [Observability](observability.md): Logging, metrics, tracing, alerting.
+- [Reliability](reliability.md): Acceptance/Integration testing in the catalogue pipeline and the front-end.

--- a/rfcs/019-platform_reliability/ci_cd.md
+++ b/rfcs/019-platform_reliability/ci_cd.md
@@ -1,0 +1,47 @@
+# CI/CD
+
+Continuous Integration / Continuous deployment
+
+## Deployment
+
+###  Continuous deployment
+
+When test pass against a build in a CI environment those changes are deployed to production.
+
+We need:
+- To be satisfied that tests in CI ensure that a build is promotable to production.
+- To build on the release tool to ensure the deploy step can actually trigger deployments.
+- To connect tests to deployment!
+
+### Deployment visibility
+
+We want to be able to see who deployed what & when in the recent past.
+
+We should provide an authenticated web dashboard showing deployments
+We want to know:
+- What was deployed, referencing:
+  - The PR that was deployed
+  - The tests that have been run against the deployed changes (pre/post deployment)
+  - The status of a deployment
+- When was a change deployed
+
+### Deployment tool 
+
+The release tooling as currently used is too complicated.
+
+We should have a single step deployment tool that takes a deploy-able artifact from a build and deploys it to an environment.
+
+```
+> cd my_project
+> wellcome_release_tool deploy build123 staging
+Congratulations abc123 (PR123, PR345) deployed to staging!
+> 
+```
+
+## Continuous integration
+
+In order to ensure that developers are able to work quickly and effectively together we should:
+
+- Reduce build times
+- Reduce test times
+- Provide clear and understandable, well documented build tooling

--- a/rfcs/019-platform_reliability/observability.md
+++ b/rfcs/019-platform_reliability/observability.md
@@ -1,0 +1,39 @@
+# Observability
+
+## Logging
+
+In order that application issues are quickly found and diagnosed logs should be easily searchable & discoverable. We should accumulate logs in a single service, with a consistent format.
+
+We should:
+
+- Send all logs to the `logging.wellcomecollection.org` ELK (Elasticsearch, Logstash, Kibana) stack.
+- Log in a consistent format to make the timestamp, originating service and environment easily searchable.
+- Remove all CloudWatch logging.
+
+## Tracing
+
+In order that application issues are quickly found and diagnosed we should be able to follow work occurring across multiple services.
+
+We should:
+
+- Implement a tracing solution in our piplelines that allow us to visualise the flow of work through our services.
+
+## Metrics
+
+In order that application issues are quickly found and diagnosed we should be able to view metrics from our applications easily.
+
+We should:
+
+- Decide on appropriate metric collectors for each of our products.
+- Decide on a single platform for visualising application metrics across our products.
+
+## Alerting
+
+In order that we can quickly react to application issues we should be notified when issues requiring our attention arise.
+
+We should:
+
+- Be able to track response to alerts and actions taken to resolve them.
+- Decide on what constitutes a critical issue (i.e. one that requires immediate action) and provide a separate channel to deliver critical alerts.
+
+

--- a/rfcs/019-platform_reliability/reliability.md
+++ b/rfcs/019-platform_reliability/reliability.md
@@ -1,0 +1,29 @@
+# Reliability
+
+In order that we can be confident that what we deploy will behave as we expect we should look at:
+
+## Pipeline reliability
+
+In order to verify that pipeline deployments will behave and are behaving as expected we should:
+
+- Test pipeline changes that require re-indexes before new indexes are promoted into production view.
+
+- Test the pipeline is performing as expected when updates flow through it both:
+  - In production
+  - In integration tests
+  
+### Pipeline reindexing 
+
+In order that we can quickly test the behaviour of the catalogue pipeline, we should:
+
+- Reduce reindex costs
+- Reduce reindex time
+- Couple reindexes with pipeline deployments (specifically model changes).  
+  
+## Front-end reliability
+
+In order to prevent regressions and errors in production we should:
+
+- Provide acceptance tests that run before release to production.
+
+- Provide component tests for individual UI components.


### PR DESCRIPTION
Following our discussion, i've aggregated what we talked about into some more general proposals that we can flesh out and work on. 

I've just tried to summarise what we said, not create specific issues to be worked on. I want to use these PR to make sure we agree in principle on the general direction, and to make sure nothing important has been missed.

When we merge this PR I will create issues from the higher level actions and add them to:

https://github.com/wellcometrust/platform/projects/12 

Uncategorised stuff has already had issues created in that project:
- https://github.com/wellcometrust/platform/issues/4237
- https://github.com/wellcometrust/platform/issues/4236
- https://github.com/wellcometrust/platform/issues/4235
- https://github.com/wellcometrust/platform/issues/4234