### PR TITLE
Add ADRs and context

### DIFF
--- a/adr/README.md
+++ b/adr/README.md
@@ -1,0 +1,9 @@
+# Architecture Decision Records (ADR)
+
+Documents here are intended to record and describe particular architectural decisions. 
+
+---
+
+An ADR records a a particular decision and contains the key information to understand how the mechanism it describes work.
+
+**An ADR is not an RFC**. An RFC is speculative and provides a place to discuss multiple options with pros and cons, which may or may not be implemented. An ADR relates only to the current implementation and will be replaced as new decisions are made.

--- a/adr/logging.md
+++ b/adr/logging.md
@@ -1,0 +1,22 @@
+# Logging
+
+Last updated: 29/06/20
+
+---
+
+Our logging implementation arises from the discussion in the [logging RFC](../rfcs/022-logging/README.md).
+
+To remove log routing logic from our application containers we use [AWS Firelens](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using_firelens.html) to transport logs from our ECS tasks directly to Elasticsearch. 
+
+Logs can be searched at [logging.wellcomecollection.org](https://logging.wellcomecollection.org) using Kibana. You will require a Wellcome account to sign in via Azure AD.
+
+Custom configuration required for the fluentbit "sidecar" container required by Firelens can be found [here](https://github.com/wellcomecollection/platform-infrastructure/tree/master/containers/fluentbit).
+
+The fluentbit "sidecar" container requires a set of secrets (Elasticsearch access details), and these are preset in the [firelens module](https://github.com/wellcomecollection/terraform-aws-ecs-service/tree/v2.6.3/modules/firelens) for our ECS services.
+
+The Elasticsearch secrets are provisioned into an AWS account from the [platform-infrastructure](https://github.com/wellcomecollection/platform-infrastructure/blob/master/critical/back_end/secrets.tf) repository. 
+
+
+
+
+

--- a/adr/secrets.md
+++ b/adr/secrets.md
@@ -1,0 +1,57 @@
+# Secrets
+
+Last updated: 29/06/20
+
+---
+
+There are various places we deal with secrets in the platform.
+
+## AWS Credentials
+
+Wellcome Collection AWS accounts are part of the wider Wellcome Trust AWS Organisation.
+
+### Root accounts
+
+Root accounts require MFA access, credentials are stored in Password Manager Pro, and accounts described in Confluence. This service is only accessible to authorised users within the Wellcome network (or with Global Protect). 
+
+All root accounts require use of the hardware MFA key stored within a firesafe on Wellcome premises.
+
+### Developer access
+
+Developers **should not** use IAM accounts to access AWS.
+
+Developer access to AWS requires a special "Wellcome Cloud" account requested from the Digital department. A normal Wellcome account is not sufficient.
+
+Access to assume particular roles within a Wellcome Collection AWS account is then made by updating an Azure AWS SSO application within the Azure console.
+
+IAM roles and federated access is provisioned via terraform.
+
+Further information is available in the [platform-infrastructure repository](https://github.com/wellcomecollection/platform-infrastructure/tree/master/accounts)
+
+### Machine accounts
+
+Where a service outside of AWS requires some access to Wellcome Collection AWS resources it is acceptable to provision an IAM user to do so. 
+
+Permissions provided to IAM users should follow the [principle of least privilege](https://en.wikipedia.org/wiki/Principle_of_least_privilege). 
+
+IAM users and their roles / permissions must always be provisioned in terraform.
+
+Thought should be given as to how to rotate credentials if necessary.
+
+#### Continuous Integration
+
+A subset of Machine accounts, we provision AWS access for Travis CI to publish artifacts via the [platform-infrastructure repo](https://github.com/wellcomecollection/platform-infrastructure/tree/master/builds).
+
+## SSH Keys
+
+There is currently not an approved mechanism for distributing SSH keys. These are shared between developers when required.
+
+## ECS
+
+ECS tasks should load secrets from [AWS SecretsManager via SSM](https://docs.aws.amazon.com/systems-manager/latest/userguide/integration-ps-secretsmanager.html).
+
+You should use the provided [container_definition](https://github.com/wellcomecollection/terraform-aws-ecs-service/tree/v2.6.3/modules/container_definition) terraform modules to facilitate this.
+
+## Terraform
+
+Terraform variables should be loaded from [SSM Parameter store](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html), _not a .tfvars file_. Secrets should never be stored in terraform state but referenced via a [SecretsManager](https://aws.amazon.com/secrets-manager/) path.

--- a/rfcs/022-logging/README.md
+++ b/rfcs/022-logging/README.md
@@ -106,8 +106,7 @@ There are a few options for routing to Elasticsearch.
   - (con) Requires some log collector infrastructure and network configuration though centralised and with a single instance of the collector service.
   
   ![Firelens configuration](firelens.png)
-  
-  
+
 
 
 

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -1,0 +1,11 @@
+# Request for comments (RFC)
+
+An RFC is a place to discuss possible changes to the Wellcome Collection platform.
+
+---
+
+Please create an RFC if you have an idea about how to make a big change to the way we do things currently and need a place to share that with your colleagues. 
+
+The process of creating an RFC, discussing that RFC in a pull request, amending and merging is important to provide a forum for all to contribute to the platform. 
+
+When an RFC is merged it provides a guide to implementing that change when it is useful to do so, or provides context to an [Architecture decision record (ADR) document](../adr/README.md).


### PR DESCRIPTION
In order that we record and share information about the current state of the platform we should use "Architecture Decision Records (ADRs)".

This PR adds:
- Rationale for ADRs
- Rationale for RFCs
- ADRs for:
  - logging
  - secrets