### PR TITLE
RFC 049: Changing how aggregations are retrieved by the Catalogue API

### DIFF
--- a/rfcs/049-catalogue-api-aggregations-modelling.md
+++ b/rfcs/049-catalogue-api-aggregations-modelling.md
@@ -171,3 +171,5 @@ This is easiest to understand with an example:
 The ingestors would populate these `aggregatableValues` fields when it indexed a work.
 
 The API would aggregate over these fields specifically, and copy the values into the `data` field of our aggregation buckets.
+
+This would allow us to reduce the amount of model logic in the API, and would ensure a consistent rendering of values in aggregations and works.

--- a/rfcs/049-catalogue-api-aggregations-modelling.md
+++ b/rfcs/049-catalogue-api-aggregations-modelling.md
@@ -1,0 +1,173 @@
+# RFC 049: Changing how aggregations are retrieved by the Catalogue API
+
+For [RFC 047], we changed the catalogue API to serialise public API responses from an opaque `display` field in the Elasticsearch documents.
+
+Previously we were storing the pipeline's internal model in Elasticsearch.
+The API would retrieve the internal model, parse it, and convert it into the display model -- all as part of serving the request.
+Now, the pipeline creates the display model and stores it in a new `display` field in Elasticsearch.
+The API retrieves the `display` field, and treats it as opaque JSON -- without any knowledge of its structure.
+
+We'd hoped this would allow us to remove the internal/display models from the API repos, but the current implementation of aggregations make this tricky.
+
+This RFC proposes a change to how aggregations are handled that should remove this obstacle.
+
+[RFC 047]: ./047-catalogue-api-index-structure.md
+
+
+
+## Context: the desired behaviour
+
+Clients of the catalogue API can request aggregations of certain values (e.g. languages, licenses, work types).
+
+These are presented as a list of `AggregationBucket` in the API responses, i.e.:
+
+```
+AggregationBucket[T] {
+  data: T
+  count: Int
+  type: String
+}
+```
+
+where `T` is the same as the value appearing in the Work model.
+
+For example, languages on a work appear as follows:
+
+```
+{
+  "languages": [
+    {
+      "id": "eng",
+      "label": "English",
+      "type": "Language"
+    },
+    {
+      "id": "fre",
+      "label": "French",
+      "type": "Language"
+    }
+  ],
+  ...
+}
+```
+
+and we see that `Language` type in the aggregation buckets:
+
+```
+"aggregations": {
+  "languages": {
+    "buckets": [
+      {
+        "data": {
+          "id": "eng",
+          "label": "English",
+          "type": "Language"
+        },
+        "count": 691840,
+        "type": "AggregationBucket"
+      },
+      {
+        "data": {
+          "id": "fre",
+          "label": "French",
+          "type": "Language"
+        },
+        "count": 67187,
+        "type": "AggregationBucket"
+      },
+...
+```
+
+This presents a clean, consistent interface to clients – a value looks the same whether it's in a work or in an aggregation.
+
+We don't to change this behaviour.
+
+
+
+## The current implementation, and the problems it poses
+
+The API uses [Elasticsearch aggregations][es_aggs] to aggregate over a field in internal model.
+Elasticsearch will return single string values, which the API then serialises into the display model.
+
+For example, our language aggregation starts as [an ES terms aggregation][terms_agg] over the `data.languages.id` field:
+
+```http
+GET /works-indexed-2022-04-28/_search
+{
+  "aggs": {
+    "languages": {
+      "terms": { "field": "data.languages.id" }
+    }
+  }
+}
+```
+
+The Elasticsearch API response can only use a single string in its buckets, for example:
+
+```
+{
+  "aggregations" : {
+    "languages" : {
+      "buckets" : [
+        {
+          "key" : "eng",
+          "doc_count" : 691840
+        },
+        {
+          "key" : "fre",
+          "doc_count" : 67187
+        },
+        ...
+```
+
+The API has to contain enough internal/display model logic to interpret these values -- to know that, say, `eng` means English and it's serialised as id/label/type.
+This is precisely the sort of model coupling we're trying to get away from.
+
+For more complex types, we've had to jump through hoops to shoehorn aggregations into this approach -- e.g. contributor values are stored like `person:Henry Wellcome` because we need both the type and the label to return them correctly.
+
+It would be nice if we could remove this coupling and simplify how aggregations work in the API.
+
+[es_aggs]: https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations.html
+[terms_agg]: https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-terms-aggregation.html
+
+
+
+## Proposed solution
+
+We add a new field `query.aggregatableValues` to the Elasticsearch model.
+This would be an object field in which the values are lists of strings:
+
+```
+type Query {
+  aggregatableValues: Map[String, List[String]]
+  ...
+}
+```
+
+The labels are the aggregation types (languages, work types, licenses) and the values are blobs of display JSON stored as strings.
+That is, we create the display JSON, then serialise the whole object as a string, and store that.
+
+This is easiest to understand with an example:
+
+```json
+{
+  "id": "example-work",
+  "query": {
+    "aggregatableValues": {
+      "languages": [
+        " { \"id\" : \"eng\", \"label\": \"English\", \"type\": \"Language\" } ",
+        " { \"id\" : \"fre\", \"label\": \"French\", \"type\": \"Language\" } "
+      ],
+      "items.locations.license": [
+        " { \"id\": \"pdm\", \"label\": \"Public Domain Mark\", \"url\": \"https://creativecommons.org/share-your-work/public-domain/pdm/\", \"type\": \"License\" } "
+      ],
+      ...
+    }
+  },
+  ...
+}
+```
+
+The ingestors would populate these `aggregatableValues` fields when it indexed a work.
+
+The API would aggregate over these fields specifically, and copy the values into the `data` field of our aggregation buckets.

--- a/rfcs/049-catalogue-api-aggregations-modelling.md
+++ b/rfcs/049-catalogue-api-aggregations-modelling.md
@@ -80,7 +80,7 @@ and we see that `Language` type in the aggregation buckets:
 
 This presents a clean, consistent interface to clients – a value looks the same whether it's in a work or in an aggregation.
 
-We don't to change this behaviour.
+We don't want to change this behaviour.
 
 
 

--- a/rfcs/049-catalogue-api-aggregations-modelling.md
+++ b/rfcs/049-catalogue-api-aggregations-modelling.md
@@ -169,6 +169,7 @@ This is easiest to understand with an example:
 ```
 
 The ingestors would populate these `aggregatableValues` fields when it indexed a work.
+This would be mapped as a `keyword` field in Elasticsearch.
 
 The API would aggregate over these fields specifically, and copy the values into the `data` field of our aggregation buckets.
 

--- a/rfcs/049-catalogue-api-aggregations-modelling/README.md
+++ b/rfcs/049-catalogue-api-aggregations-modelling/README.md
@@ -169,6 +169,36 @@ This is easiest to understand with an example:
 The ingestors would populate these `aggregatableValues` fields when it indexed a work.
 This would be mapped as a `keyword` field in Elasticsearch.
 
+e.g.
+
+```
+aggregatableValues = {
+    languages: [
+        lang.to_display_json().as_string()
+        for lang in work.languages
+    ],
+    items.locations.license: [
+        license.to_display_json().as_string()
+        for license in items.locations
+    ],
+    ...
+}
+```
+
 The API would aggregate over these fields specifically, and copy the values into the `data` field of our aggregation buckets.
+
+```
+# api
+
+displayBuckets = [
+    {
+        data: parse_json(bucket.key),
+        count: bucket.count,
+        type: "AggregationBucket"
+    }
+    for bucket in es_aggregations_response
+]
+
+```
 
 This would allow us to reduce the amount of model logic in the API, and would ensure a consistent rendering of values in aggregations and works.

--- a/rfcs/049-catalogue-api-aggregations-modelling/README.md
+++ b/rfcs/049-catalogue-api-aggregations-modelling/README.md
@@ -169,8 +169,6 @@ This is easiest to understand with an example:
 The ingestors would populate these `aggregatableValues` fields when it indexed a work.
 This would be mapped as a `keyword` field in Elasticsearch.
 
-e.g.
-
 ```
 aggregatableValues = {
     languages: [
@@ -185,7 +183,26 @@ aggregatableValues = {
 }
 ```
 
-The API would aggregate over these fields specifically, and copy the values into the `data` field of our aggregation buckets.
+The API would aggregate over these fields specifically.
+The Elasticsearch terms aggregation would return something like:
+
+```
+{
+  "aggregations" : {
+    "languages" : {
+      "buckets" : [
+        {
+          "key" : " { \"id\" : \"eng\", \"label\": \"English\", \"type\": \"Language\" } ",
+          "doc_count" : 691840
+        },
+        {
+          "key" : " { \"id\" : \"fre\", \"label\": \"French\", \"type\": \"Language\" } ",
+          "doc_count" : 67187
+        },
+        ...
+```
+
+and the API would unpack the `keys` as opaque JSON objects, and pass the value into its response:""
 
 ```
 # api

--- a/rfcs/049-catalogue-api-aggregations-modelling/README.md
+++ b/rfcs/049-catalogue-api-aggregations-modelling/README.md
@@ -135,7 +135,6 @@ It would be nice if we could remove this coupling and simplify how aggregations 
 ## Proposed solution
 
 We add a new field `query.aggregatableValues` to the documents we store in Elasticsearch.
-This would be an object field in which the values are lists of strings:
 
 ```
 type Query {
@@ -144,8 +143,7 @@ type Query {
 }
 ```
 
-The labels are the aggregation types (languages, work types, licenses) and the values are blobs of display JSON stored as strings.
-That is, we create the display JSON, then serialise the whole object as a string, and store that.
+where the keys are the aggregation types (languages, work types, licenses) and the values are lists of display JSON stored as strings.
 
 This is easiest to understand with an example:
 

--- a/rfcs/049-catalogue-api-aggregations-modelling/README.md
+++ b/rfcs/049-catalogue-api-aggregations-modelling/README.md
@@ -134,7 +134,7 @@ It would be nice if we could remove this coupling and simplify how aggregations 
 
 ## Proposed solution
 
-We add a new field `query.aggregatableValues` to the Elasticsearch model.
+We add a new field `query.aggregatableValues` to the documents we store in Elasticsearch.
 This would be an object field in which the values are lists of strings:
 
 ```

--- a/rfcs/049-catalogue-api-aggregations-modelling/README.md
+++ b/rfcs/049-catalogue-api-aggregations-modelling/README.md
@@ -11,7 +11,7 @@ We'd hoped this would allow us to remove the internal/display models from the AP
 
 This RFC proposes a change to how aggregations are handled that should remove this obstacle.
 
-[RFC 047]: ./047-catalogue-api-index-structure.md
+[RFC 047]: ../047-catalogue-api-index-structure.md
 
 
 

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -19,4 +19,11 @@ When an RFC is merged it provides a guide to implementing that change when it is
   <dd>
     Updating the catalogue API to serialise responses from an opaque <code>display</code> field, rather than parsing the internal model structure used by the pipeline.
   </dd>
+
+  <dt>
+    <a href="./049-catalogue-api-aggregations-modelling.md">RFC 049</a>: Changing how aggregations are retrieved by the Catalogue API
+  </dt>
+  <dd>
+    Updating aggregations to match the changes from RFC 047 and to reduce the coupling between the pipeline/API repos.
+  </dd>
 </dl>

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -4,8 +4,19 @@ An RFC is a place to discuss possible changes to the Wellcome Collection platfor
 
 ---
 
-Please create an RFC if you have an idea about how to make a big change to the way we do things currently and need a place to share that with your colleagues. 
+Please create an RFC if you have an idea about how to make a big change to the way we do things currently and need a place to share that with your colleagues.
 
-The process of creating an RFC, discussing that RFC in a pull request, amending and merging is important to provide a forum for all to contribute to the platform. 
+The process of creating an RFC, discussing that RFC in a pull request, amending and merging is important to provide a forum for all to contribute to the platform.
 
 When an RFC is merged it provides a guide to implementing that change when it is useful to do so, or provides context to an [Architecture decision record (ADR) document](../adr/README.md).
+
+## Table of contents
+
+<dl>
+  <dt>
+    <a href="./047-catalogue-api-index-structure.md">RFC 047</a>: Changing the structure of the Catalogue API index
+  </dt>
+  <dd>
+    Updating the catalogue API to serialise responses from an opaque <code>display</code> field, rather than parsing the internal model structure used by the pipeline.
+  </dd>
+</dl>

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -21,7 +21,7 @@ When an RFC is merged it provides a guide to implementing that change when it is
   </dd>
 
   <dt>
-    <a href="./049-catalogue-api-aggregations-modelling.md">RFC 049</a>: Changing how aggregations are retrieved by the Catalogue API
+    <a href="./049-catalogue-api-aggregations-modelling">RFC 049</a>: Changing how aggregations are retrieved by the Catalogue API
   </dt>
   <dd>
     Updating aggregations to match the changes from RFC 047 and to reduce the coupling between the pipeline/API repos.


### PR DESCRIPTION
Rendered version: https://github.com/wellcomecollection/docs/blob/aggregations-modelling/rfcs/049-catalogue-api-aggregations-modelling/README.md

This is part of https://github.com/wellcomecollection/platform/issues/5530. I posted it as a Slack thread late last night, but I realised it's big and complicated enough to be worth explaining and discussing in a proper RFC, and not a half-baked Slack post.