### PR TITLE
076: Enriching catalogue API data from the knowledge graph

### DIFF
--- a/rfcs/076-catalogue-api-knowledge-graph/README.md
+++ b/rfcs/076-catalogue-api-knowledge-graph/README.md
@@ -1,10 +1,11 @@
 # RFC 076: Enriching catalogue API data from the knowledge graph
 
-Draft
+_Draft_
 
 [GitHub issue](https://github.com/wellcomecollection/platform/issues/6047)
 
 ## Related works
-We wanted to document some of the current logic currently in use on the Front-End. The current implementation is a temporary one while the component is being tested and improved upon, and so it is likely to change. Those changes will also be documented. We thought it was relevant to document it here as its final solution will very probably benefit from this work. Feel free to completely restructure this, or to move it elsewhere when you get to tackling this RFC.
 
-[Current related work logic](./current-logic.md)
+This section documents the logic currently used on the Front-End to display related works. The implementation described here is provisional and may evolve as the component is tested and refined. Any future changes will also be recorded. Documenting this logic is intended to inform and support the development of a more robust, long-term solution as part of this RFC.
+
+For details, see: [Current related work logic](./current-logic.md)

--- a/rfcs/076-catalogue-api-knowledge-graph/README.md
+++ b/rfcs/076-catalogue-api-knowledge-graph/README.md
@@ -1,4 +1,4 @@
-# RFC 076: RFC: Enriching catalogue API data from the knowledge graph
+# RFC 076: Enriching catalogue API data from the knowledge graph
 
 Draft
 
@@ -6,3 +6,5 @@ Draft
 
 ## Related works
 We wanted to document some of the current logic currently in use on the Front-End. The current implementation is a temporary one while the component is being tested and improved upon, and so it is likely to change. Those changes will also be documented. We thought it was relevant to document it here as its final solution will very probably benefit from this work. Feel free to completely restructure this, or to move it elsewhere when you get to tackling this RFC.
+
+[Current related work logic](./current-logic.md)

--- a/rfcs/076-catalogue-api-knowledge-graph/README.md
+++ b/rfcs/076-catalogue-api-knowledge-graph/README.md
@@ -1,0 +1,8 @@
+# RFC 076: RFC: Enriching catalogue API data from the knowledge graph
+
+Draft
+
+[GitHub issue](https://github.com/wellcomecollection/platform/issues/6047)
+
+## Related works
+We wanted to document some of the current logic currently in use on the Front-End. The current implementation is a temporary one while the component is being tested and improved upon, and so it is likely to change. Those changes will also be documented. We thought it was relevant to document it here as its final solution will very probably benefit from this work. Feel free to completely restructure this, or to move it elsewhere when you get to tackling this RFC.

--- a/rfcs/076-catalogue-api-knowledge-graph/current-logic.md
+++ b/rfcs/076-catalogue-api-knowledge-graph/current-logic.md
@@ -3,28 +3,33 @@
 There have been [a few different tickets](https://github.com/wellcomecollection/wellcomecollection.org/milestone/78) tackling the desired MVP logic for the [Related works component](https://github.com/wellcomecollection/wellcomecollection.org/tree/main/content/webapp/components/RelatedWorks) and even more conversations around what we think should be queried. Because of the amount of people involved, we thought it best to document those decisions somewhere. It is likely to change and be improved upon.
 
 ## Resources
+
 - [Final design and spec](https://www.figma.com/design/6ZvjrD9yhBBZSAXENc8vK4/Related-content-on-Works-pages?node-id=532-7370&p=f&m=dev)
 - [Related works component](https://github.com/wellcomecollection/wellcomecollection.org/tree/main/content/webapp/components/RelatedWorks)
 - [This .org helpers file](https://github.com/wellcomecollection/wellcomecollection.org/blob/main/content/webapp/components/RelatedWorks/RelatedWorks.helpers.tsx) containing the queries
 
 ## Table of contents
+
 - [Related works component](#related-works-component)
 - [Current queries](#current-queries)
-    - [Subject related queries](#subject-related-queries)
-    - [Date range](#date-range)
+  - [Subject related queries](#subject-related-queries)
+  - [Date range](#date-range)
   - [Genres](#genres)
 - [Query changes](#query-changes)
 - [Interesting works to consider](#interesting-works-to-consider)
-    - [Date range vs date-related subject label](#date-range-vs-date-related-subject-label)
-    - [Same results](#same-results)
+  - [Date range vs date-related subject label](#date-range-vs-date-related-subject-label)
+  - [Same results](#same-results)
 
 ## Related works component
+
 The component [gets added to a works page](https://github.com/wellcomecollection/wellcomecollection.org/blob/main/content/webapp/pages/works/%5BworkId%5D/index.tsx#L207) if the work has at least one subject label.
 
 ## Current queries
+
 The base of all queries lies with the subject labels. If a work does not have any subject labels, we don't query for the others at all, since their results would be too generic.
 
 The queries are split into three categories:
+
 - Subject related
 - From the same century (date range) with similar subjects
 - Genres related, with similar subjects
@@ -34,25 +39,31 @@ For each query we fetch 4 works, because we want to display 3 and the work being
 We query a maximum of three individual subjects, a date range if it can be determined and up to two genres. There can therefore be up of six queries made on each work page.
 
 ### Subject related queries
+
 Up to three queries/tabs.
 Uses the first three subjects from the response array.
 
 #### Query
+
 - `pageSize: 4`
 - `includes: [production, contributor]` - required for the display data we need for cards
 - `subjects.label: one of the first three subject labels of the work`
 
 ### Date range
+
 One query/tab
 Used for a "Century" tab, e.g. "From 1900s".
 
-#### Queried if the date is a string made of four numbers. 
+#### Queried if the date is a string made of four numbers.
+
 Valid:
+
 - `1999`
 - `1284`
 - `1683`
 
 Not valid:
+
 - `[1928]`
 - `1937?`
 - `From 1930 to 1934`
@@ -61,6 +72,7 @@ Not valid:
 If the string is valid, we then use it to [get the century range](https://github.com/wellcomecollection/wellcomecollection.org/blob/main/content/webapp/components/RelatedWorks/RelatedWorks.helpers.tsx#L13-L30).
 
 #### Query
+
 - `pageSize: 4`
 - `includes: [production, contributor]`
 - `subjects.label: the first three subject labels of the work`
@@ -78,22 +90,25 @@ We get the first two genres in the response array:
 So up to two queries are done, by looping through the above's results:
 
 #### Query
+
 - `pageSize: 4`
 - `includes: [production, contributor]`
 - `subjects.label: the first three subject labels of the work`
 - `genres.label: The genre label`
 
 ## Interesting works to consider
-Throughout our work, we found some works whose related works results made it clear more work would be required on the logic.
+
+We have found some related works results that made it clear more work would be required on the logic.
 
 ### Date range vs date-related subject label
+
 https://wellcomecollection.org/works/a2262ru9
 https://wellcomecollection.org/works/a376cmj9
 
-It's strange when one of the subject label is date related, because we then also have the century tab. That can be the same century, or a different work if the work is a modern one about a different century.
+It's strange when one of the subject label is date related, because we then also have the century tab. That can be the same century or a different one, if the work is a modern one about a different century.
 
 ### Same results
+
 https://wellcomecollection.org/works/a22xvp3c
 
-Many works will display the same results for most of their tabs. The answer would be to fetch more works and compare and filter, but we chose to not to that at this stage.
-
+Many works will display the same results for most of their tabs. An answer would be to fetch more works and compare/filternthem, but we chose not to do that at this stage.

--- a/rfcs/076-catalogue-api-knowledge-graph/current-logic.md
+++ b/rfcs/076-catalogue-api-knowledge-graph/current-logic.md
@@ -1,0 +1,30 @@
+There have been [a few different tickets](https://github.com/wellcomecollection/wellcomecollection.org/milestone/78) tackling the desired MVP logic for the [Related works component](https://github.com/wellcomecollection/wellcomecollection.org/tree/main/content/webapp/components/RelatedWorks). There have been a lot of different conversations around what we think should be queried, and we thought it best to document it somewhere. It is likely to change and be improved upon.
+
+[Final design and spec](https://www.figma.com/design/6ZvjrD9yhBBZSAXENc8vK4/Related-content-on-Works-pages?node-id=532-7370&p=f&m=dev)
+
+## Related works component
+The component gets added to a page if ...
+
+## Current queries
+The base of all queries lies with the subject labels. 
+If a work does not have any subject labels, we don't query for the others at all.
+
+### Subject labels
+
+### Date range
+One tab
+Century
+Queried if the date is a string made of four numbers. 
+Valid:
+- `1999`
+- `1284`
+- `1683`
+
+Not valid:
+- `[1928]`
+- `1937?`
+- `From 1930 to 1934`
+- `1933-1954`
+
+### Types/techniques
+Maximum of 2 tabs

--- a/rfcs/076-catalogue-api-knowledge-graph/current-logic.md
+++ b/rfcs/076-catalogue-api-knowledge-graph/current-logic.md
@@ -111,4 +111,4 @@ It's strange when one of the subject label is date related, because we then also
 
 https://wellcomecollection.org/works/a22xvp3c
 
-Many works will display the same results for most of their tabs. An answer would be to fetch more works and compare/filternthem, but we chose not to do that at this stage.
+Many works will display the same results for most of their tabs. An answer would be to fetch more works and compare/filter them, but we chose not to do that at this stage.

--- a/rfcs/076-catalogue-api-knowledge-graph/current-logic.md
+++ b/rfcs/076-catalogue-api-knowledge-graph/current-logic.md
@@ -24,7 +24,7 @@ The component [gets added to a works page](https://github.com/wellcomecollection
 ## Current queries
 The base of all queries lies with the subject labels. If a work does not have any subject labels, we don't query for the others at all, since their results would be too generic.
 
-The queries are split in three categories:
+The queries are split into three categories:
 - Subject related
 - From the same century (date range) with similar subjects
 - Genres related, with similar subjects

--- a/rfcs/076-catalogue-api-knowledge-graph/current-logic.md
+++ b/rfcs/076-catalogue-api-knowledge-graph/current-logic.md
@@ -83,9 +83,6 @@ So up to two queries are done, by looping through the above's results:
 - `subjects.label: the first three subject labels of the work`
 - `genres.label: The genre label`
 
-## Query changes
-(For Gareth) We used to pass the subject, date or genre label as a keyword search, but removing it seemed to change nothing, so I did. Was that a decision that I shouldn't have touched?
-
 ## Interesting works to consider
 Throughout our work, we found some works whose related works results made it clear more work would be required on the logic.
 

--- a/rfcs/076-catalogue-api-knowledge-graph/current-logic.md
+++ b/rfcs/076-catalogue-api-knowledge-graph/current-logic.md
@@ -39,8 +39,8 @@ Uses the first three subjects from the response array.
 
 #### Query
 - `pageSize: 4`
-- `includes: [production, contributor]`
-- `subjects.label: the first three subject labels of the work`
+- `includes: [production, contributor]` - required for the display data we need for cards
+- `subjects.label: one of the first three subject labels of the work`
 
 ### Date range
 One query/tab

--- a/rfcs/076-catalogue-api-knowledge-graph/current-logic.md
+++ b/rfcs/076-catalogue-api-knowledge-graph/current-logic.md
@@ -31,7 +31,7 @@ The queries are split in three categories:
 
 For each query we fetch 4 works, because we want to display 3 and the work being viewed is likely to be returned as a result. We filter it out afterwards.
 
-There can therefore be up of six queries made on each work page.
+We query a maximum of three individual subjects, a date range if it can be determined and up to two genres. There can therefore be up of six queries made on each work page.
 
 ### Subject related queries
 Up to three queries/tabs.

--- a/rfcs/076-catalogue-api-knowledge-graph/current-logic.md
+++ b/rfcs/076-catalogue-api-knowledge-graph/current-logic.md
@@ -12,7 +12,7 @@ There have been [a few different tickets](https://github.com/wellcomecollection/
 - [Current queries](#current-queries)
     - [Subject related queries](#subject-related-queries)
     - [Date range](#date-range)
-    - [Types/techniques](#typestechniques)
+  - [Genres](#genres)
 - [Query changes](#query-changes)
 - [Interesting works to consider](#interesting-works-to-consider)
     - [Date range vs date-related subject label](#date-range-vs-date-related-subject-label)
@@ -27,7 +27,7 @@ The base of all queries lies with the subject labels. If a work does not have an
 The queries are split in three categories:
 - Subject related
 - From the same century (date range) with similar subjects
-- Types/Techniques related, with similar subjects
+- Genres related, with similar subjects
 
 For each query we fetch 4 works, because we want to display 3 and the work being viewed is likely to be returned as a result. We filter it out afterwards.
 
@@ -67,12 +67,12 @@ If the string is valid, we then use it to [get the century range](https://github
 - `production.dates.from: First day of the century`
 - `production.dates.to: Last day of the century`
 
+### Genres
 
-### Types/techniques
-Maximum of 2 queries/tabs, but only because we wanted to reduce the amount of total queries. 
-The original request was for up to 3 tabs for types and techniques.
+Maximum of 2 genres/tabs, but only because we wanted to reduce the amount of total queries.
+The original request was for up to 3 tabs for genres.
 
-We get the first two types/techniques (genres) in the response array:
+We get the first two genres in the response array:
 `genres?.map(genre => genre.label).slice(0, 2)`
 
 So up to two queries are done, by looping through the above's results:

--- a/rfcs/076-catalogue-api-knowledge-graph/current-logic.md
+++ b/rfcs/076-catalogue-api-knowledge-graph/current-logic.md
@@ -8,12 +8,15 @@ There have been [a few different tickets](https://github.com/wellcomecollection/
 - [This .org helpers file](https://github.com/wellcomecollection/wellcomecollection.org/blob/main/content/webapp/components/RelatedWorks/RelatedWorks.helpers.tsx) containing the queries
 
 ## Table of contents
-- [Related works component (FE)](#related-works-component)
+- [Related works component](#related-works-component)
 - [Current queries](#current-queries)
     - [Subject related queries](#subject-related-queries)
     - [Date range](#date-range)
     - [Types/techniques](#typestechniques)
+- [Query changes](#query-changes)
 - [Interesting works to consider](#interesting-works-to-consider)
+    - [Date range vs date-related subject label](#date-range-vs-date-related-subject-label)
+    - [Same results](#same-results)
 
 ## Related works component
 The component [gets added to a works page](https://github.com/wellcomecollection/wellcomecollection.org/blob/main/content/webapp/pages/works/%5BworkId%5D/index.tsx#L207) if the work has at least one subject label.
@@ -86,10 +89,14 @@ So up to two queries are done, by looping through the above's results:
 ## Interesting works to consider
 Throughout our work, we found some works whose related works results made it clear more work would be required on the logic.
 
+### Date range vs date-related subject label
 https://wellcomecollection.org/works/a2262ru9
 https://wellcomecollection.org/works/a376cmj9
+
 It's strange when one of the subject label is date related, because we then also have the century tab. That can be the same century, or a different work if the work is a modern one about a different century.
 
+### Same results
 https://wellcomecollection.org/works/a22xvp3c
+
 Many works will display the same results for most of their tabs. The answer would be to fetch more works and compare and filter, but we chose to not to that at this stage.
 

--- a/rfcs/076-catalogue-api-knowledge-graph/current-logic.md
+++ b/rfcs/076-catalogue-api-knowledge-graph/current-logic.md
@@ -1,20 +1,49 @@
-There have been [a few different tickets](https://github.com/wellcomecollection/wellcomecollection.org/milestone/78) tackling the desired MVP logic for the [Related works component](https://github.com/wellcomecollection/wellcomecollection.org/tree/main/content/webapp/components/RelatedWorks). There have been a lot of different conversations around what we think should be queried, and we thought it best to document it somewhere. It is likely to change and be improved upon.
+# Logic and background for Related works queries
 
-[Final design and spec](https://www.figma.com/design/6ZvjrD9yhBBZSAXENc8vK4/Related-content-on-Works-pages?node-id=532-7370&p=f&m=dev)
+There have been [a few different tickets](https://github.com/wellcomecollection/wellcomecollection.org/milestone/78) tackling the desired MVP logic for the [Related works component](https://github.com/wellcomecollection/wellcomecollection.org/tree/main/content/webapp/components/RelatedWorks) and even more conversations around what we think should be queried. Because of the amount of people involved, we thought it best to document those decisions somewhere. It is likely to change and be improved upon.
+
+## Resources
+- [Final design and spec](https://www.figma.com/design/6ZvjrD9yhBBZSAXENc8vK4/Related-content-on-Works-pages?node-id=532-7370&p=f&m=dev)
+- [Related works component](https://github.com/wellcomecollection/wellcomecollection.org/tree/main/content/webapp/components/RelatedWorks)
+- [This .org helpers file](https://github.com/wellcomecollection/wellcomecollection.org/blob/main/content/webapp/components/RelatedWorks/RelatedWorks.helpers.tsx) containing the queries
+
+## Table of contents
+- [Related works component (FE)](#related-works-component)
+- [Current queries](#current-queries)
+    - [Subject related queries](#subject-related-queries)
+    - [Date range](#date-range)
+    - [Types/techniques](#typestechniques)
+- [Interesting works to consider](#interesting-works-to-consider)
 
 ## Related works component
-The component gets added to a page if ...
+The component [gets added to a works page](https://github.com/wellcomecollection/wellcomecollection.org/blob/main/content/webapp/pages/works/%5BworkId%5D/index.tsx#L207) if the work has at least one subject label.
 
 ## Current queries
-The base of all queries lies with the subject labels. 
-If a work does not have any subject labels, we don't query for the others at all.
+The base of all queries lies with the subject labels. If a work does not have any subject labels, we don't query for the others at all, since their results would be too generic.
 
-### Subject labels
+The queries are split in three categories:
+- Subject related
+- From the same century (date range) with similar subjects
+- Types/Techniques related, with similar subjects
+
+For each query we fetch 4 works, because we want to display 3 and the work being viewed is likely to be returned as a result. We filter it out afterwards.
+
+There can therefore be up of six queries made on each work page.
+
+### Subject related queries
+Up to three queries/tabs.
+Uses the first three subjects from the response array.
+
+#### Query
+- `pageSize: 4`
+- `includes: [production, contributor]`
+- `subjects.label: the first three subject labels of the work`
 
 ### Date range
-One tab
-Century
-Queried if the date is a string made of four numbers. 
+One query/tab
+Used for a "Century" tab, e.g. "From 1900s".
+
+#### Queried if the date is a string made of four numbers. 
 Valid:
 - `1999`
 - `1284`
@@ -26,5 +55,41 @@ Not valid:
 - `From 1930 to 1934`
 - `1933-1954`
 
+If the string is valid, we then use it to [get the century range](https://github.com/wellcomecollection/wellcomecollection.org/blob/main/content/webapp/components/RelatedWorks/RelatedWorks.helpers.tsx#L13-L30).
+
+#### Query
+- `pageSize: 4`
+- `includes: [production, contributor]`
+- `subjects.label: the first three subject labels of the work`
+- `production.dates.from: First day of the century`
+- `production.dates.to: Last day of the century`
+
+
 ### Types/techniques
-Maximum of 2 tabs
+Maximum of 2 queries/tabs, but only because we wanted to reduce the amount of total queries. 
+The original request was for up to 3 tabs for types and techniques.
+
+We get the first two types/techniques (genres) in the response array:
+`genres?.map(genre => genre.label).slice(0, 2)`
+
+So up to two queries are done, by looping through the above's results:
+
+#### Query
+- `pageSize: 4`
+- `includes: [production, contributor]`
+- `subjects.label: the first three subject labels of the work`
+- `genres.label: The genre label`
+
+## Query changes
+(For Gareth) We used to pass the subject, date or genre label as a keyword search, but removing it seemed to change nothing, so I did. Was that a decision that I shouldn't have touched?
+
+## Interesting works to consider
+Throughout our work, we found some works whose related works results made it clear more work would be required on the logic.
+
+https://wellcomecollection.org/works/a2262ru9
+https://wellcomecollection.org/works/a376cmj9
+It's strange when one of the subject label is date related, because we then also have the century tab. That can be the same century, or a different work if the work is a modern one about a different century.
+
+https://wellcomecollection.org/works/a22xvp3c
+Many works will display the same results for most of their tabs. The answer would be to fetch more works and compare and filter, but we chose to not to that at this stage.
+


### PR DESCRIPTION
## What does this change?

Fringe of [Platform RFC ticket](https://github.com/wellcomecollection/platform/issues/6047)
But currently mostly for the ["Related content on works pages" Experience milestone](https://github.com/wellcomecollection/wellcomecollection.org/milestone/78)
[Documentation ticket](https://github.com/wellcomecollection/wellcomecollection.org/issues/12005)

WIP.

[Current related work queries](https://github.com/wellcomecollection/docs/blob/076-enriching-catalogue-api-kg/rfcs/076-catalogue-api-knowledge-graph/current-logic.md)
[README](https://github.com/wellcomecollection/docs/blob/076-enriching-catalogue-api-kg/rfcs/076-catalogue-api-knowledge-graph/README.md)
