### PR TITLE
RFC 086: Item viewer refactoring plan

### DIFF
--- a/rfcs/086-item-viewer-refactor/01-overview.md
+++ b/rfcs/086-item-viewer-refactor/01-overview.md
@@ -1,0 +1,94 @@
+# Overview
+
+[← Back to Index](./README.md)
+
+## Problem Statement
+
+The IIIF Viewer component tree has significant duplication of logic and calculations across multiple components. Values like `currentCanvas`, download options, image services, and derived state are computed independently in different files, leading to:
+
+- Code duplication (~60% of calculations repeated)
+- Harder maintenance (changes needed in multiple places)
+- Potential inconsistencies between components
+- Missed optimisation opportunities (no memoisation)
+- Verbose component code
+
+## Current Architecture
+
+### ItemViewerContext (Already Exists)
+**Location:** `content/webapp/contexts/ItemViewerContext/index.tsx`
+
+Currently provides:
+- UI state (sidebar visibility, zoom, grid, fullscreen)
+- Basic data (work, transformedManifest, query params)
+- Refs (viewerRef, mainAreaRef)
+- Missing: Derived/computed values used across components
+
+### Components with Duplication
+
+| Component | Duplicated Logic |
+|-----------|------------------|
+| `IIIFViewer.tsx` | `currentCanvas`, `canvasIndexById`, `hasOnlyRenderableImages`, `hasMultipleCanvases`, `mainImageService`, `urlTemplate` |
+| `ViewerTopBar.tsx` | `currentCanvas`, `imageServices` extraction, download options (50+ lines), `isRestricted` |
+| `ZoomedImage.tsx` | `currentCanvas`, `mainImageService` |
+| `MainViewer.tsx` | `currentCanvas` access, rotation calculations |
+| `Thumbnails.tsx` | `queryParamToArrayIndex` calls |
+| `NoScriptImage.tsx` | `queryParamToArrayIndex` calls |
+
+### Specific Duplication Examples
+
+**`currentCanvas` - calculated in 4+ files:**
+```typescript
+// IIIFViewer.tsx line 257
+const currentCanvas = transformedManifest?.canvases[queryParamToArrayIndex(canvas)];
+
+// ViewerTopBar.tsx line 224  
+const currentCanvas = canvases?.[queryParamToArrayIndex(query.canvas)];
+
+// ZoomedImage.tsx line 55-56
+const currentCanvas = transformedManifest?.canvases[queryParamToArrayIndex(query.canvas)];
+```
+
+**Download options logic - only in `ViewerTopBar.tsx` (lines 245-291):**
+- Calculate `iiifImageDownloadOptions`
+- Extract `canvasImageDownloads` from `imageServices`
+- Get `canvasDownloadOptions` from current canvas
+- Get `manifestDownloadOptions` from rendering
+- Get `videoAudioDownloadOptions`
+- Combine all options
+- Deduplicate by download URL (added in `restricted-images` merge)
+
+**Note:** Download logic is only in one file, but it's ~65 lines of complex business logic (now ~80 with deduplication). **This will go into a custom hook** (not context) for testability and potential reuse.
+
+**Image services extraction - `ViewerTopBar.tsx` (lines 226-238):**
+Complex mapping with `ChoiceBody` handling, only done once but could be reusable.
+
+## What Goes Where?
+
+### Context (`ItemViewerContextV2`)
+**Use for:** Values needed by **2+ components** OR likely to be needed by multiple components soon.
+
+Moving to context:
+- `currentCanvas` - used in 4 files
+- `currentCanvasIndex` - used in 3+ files
+- `mainImageService` - used in 2 files
+- `hasMultipleCanvases` - affects layout across components
+- Navigation booleans - used by navigation UI across components
+- `isCurrentCanvasRestricted` - only in `ViewerTopBar` now, but likely needed for download restrictions, visibility rules, etc.
+
+### Custom Hook
+**Use for:** Complex logic that's **reusable or needs testing**, even if only used in one place.
+
+Moving to hook:
+- Download options logic - 65 lines, complex business logic, only in `ViewerTopBar` but worth extracting for testability
+
+### Local Component State
+**Use for:** Simple logic only used in **one component** with no reuse potential.
+
+Staying local:
+- Component-specific UI state
+- Simple calculations not shared
+- One-off transformations
+
+---
+
+**Next:** [02 - Normalisation Strategy](./02-normalisation-strategy.md)

--- a/rfcs/086-item-viewer-refactor/02-normalisation-strategy.md
+++ b/rfcs/086-item-viewer-refactor/02-normalisation-strategy.md
@@ -1,0 +1,40 @@
+# Normalisation Strategy
+
+[← Back to Index](./README.md)
+
+**Key principle:** When centralising duplicated logic, we normalise to a single canonical implementation even when variants differ slightly.
+
+## Why Normalise Variations?
+
+The duplicated calculations aren't always exactly identical - they have minor variations in:
+- Access patterns (`canvas` destructured vs `query.canvas` direct access - same value, different syntax)
+- Optional chaining depth (`canvases?.[...]` vs `transformedManifest?.canvases[...]`)
+- Fallback values (some have `|| ''`, others allow undefined - need to determine which is correct)
+
+We still centralise these because:
+1. They compute the same logical value - just with different syntax
+2. Normalisation prevents drift - variations can grow into bugs over time
+3. Reduces cognitive load - one canonical way to access the value
+4. Makes changes easier - update once, not in 4 places
+
+## Choosing the Canonical Implementation
+
+For each duplicated value, we choose the most defensive/complete version:
+
+| Value | Current Variations | Canonical Version | Rationale |
+|-------|-------------------|-------------------|-----------|
+| `currentCanvas` | `canvases?.[i]` vs `transformedManifest?.canvases[i]` (accessing same data via different paths) | Use `transformedManifest?.canvases[i]` | More explicit about data source |
+| `mainImageService` | With/without `\|\| ''` fallback | Include `\|\| ''` only if downstream code requires it | `ZoomedImage` has fallback because `convertRequestUriToInfoUri` expects string. `IIIFViewer` doesn't need it. **Check actual usage before adding fallback.** |
+| `hasMultipleCanvases` | Not in context | Add to context | Calculated in `IIIFViewer`, used in multiple components |
+
+## Normalisation Testing Requirements
+
+For each normalised value, verify that:
+1. Original behaviour preserved - components work identically with context version
+2. Edge cases handled - undefined/null cases don't break
+3. Type safety maintained - TypeScript types are correct
+4. Fallback behaviour tested - **verify fallbacks are only added where genuinely needed**
+
+---
+
+**Next:** [03 - Naming Conventions](./03-naming-conventions.md)

--- a/rfcs/086-item-viewer-refactor/03-naming-conventions.md
+++ b/rfcs/086-item-viewer-refactor/03-naming-conventions.md
@@ -1,0 +1,120 @@
+# Naming Conventions: Crystal-Clear Boolean Values
+
+[←Back to Index](./README.md)
+
+**Core Principle:** Components should just read clear boolean values from context, not calculate them. No confusing conditionals scattered across components.
+
+## Good vs Bad Naming
+
+Bad (unclear):
+```typescript
+const restricted = work.access?.restrictedAccessStatus;
+const digital = work.production?.some(p => p.type === 'BornDigital');
+const imgs = canvases.every(c => c.type === 'Image');
+```
+
+Good (crystal clear):
+```typescript
+const { 
+  isCurrentCanvasRestricted,
+  isWorkBornDigital,
+  hasOnlyRenderableImages,
+  hasMultipleCanvases,
+  hasIiifImageService,
+  hasDownloadableAssets,
+  isFullscreenAvailable,
+} = useItemViewerContextV2();
+```
+
+## Boolean Naming Pattern
+
+All boolean values follow this pattern:
+- **`is...`** - for state/status checks (isRestricted, isBornDigital, isFullscreen)
+- **`has...`** - for existence checks (hasImages, hasMultipleCanvases, hasDownloadOptions)
+- **`can...`** - for permission/ability checks (canDownload, canZoom, canShare)
+- **`should...`** - for conditional rendering (shouldShowThumbnails, shouldUseIiifLocation)
+
+## Comprehensive Derived Boolean Values
+
+These should ALL be in `ItemViewerContextV2`, not calculated in components:
+
+### Canvas-Related
+```typescript
+isCurrentCanvasRestricted: boolean;        // Current canvas has restricted access
+hasMultipleCanvases: boolean;              // Work has more than one canvas
+isFirstCanvas: boolean;                    // Currently viewing first canvas
+isLastCanvas: boolean;                     // Currently viewing last canvas
+canNavigateNext: boolean;                  // Next canvas available
+canNavigatePrevious: boolean;              // Previous canvas available
+```
+
+### Image Service Related
+```typescript
+hasIiifImageService: boolean;              // Current canvas has IIIF image service
+hasIiifImage: boolean;                     // Has IIIF image (service or location)
+shouldUseIiifImageLocation: boolean;       // Should use location instead of service
+hasOnlyRenderableImages: boolean;          // All canvases are renderable images
+isImageZoomable: boolean;                  // Current image supports zoom
+```
+
+### Work Type Related
+```typescript
+isWorkBornDigital: boolean;                // Work was born digital
+isArchiveItem: boolean;                    // Work is archive material
+hasVideoContent: boolean;                  // Work contains video
+hasAudioContent: boolean;                  // Work contains audio
+hasPdfDownload: boolean;                   // Work has PDF available
+```
+
+### Download Related
+```typescript
+hasDownloadOptions: boolean;               // Any download options available
+hasImageDownloads: boolean;                // Image downloads available
+hasManifestDownloads: boolean;             // Manifest-level downloads available
+canDownloadCurrentCanvas: boolean;         // Current canvas is downloadable
+```
+
+### UI State Related
+```typescript
+isFullscreenActive: boolean;               // Currently in fullscreen mode
+isSidebarVisible: boolean;                 // Sidebar is visible
+isGridViewActive: boolean;                 // Grid view is active
+isZoomActive: boolean;                     // Zoom is active
+canToggleFullscreen: boolean;              // Fullscreen is supported
+```
+
+## Benefits of Clear Naming
+
+1. Self-documenting code - `isCurrentCanvasRestricted` needs no comment
+2. Easier debugging - Immediately understand what condition is being checked
+3. Reduces errors - Less likely to misunderstand intent
+4. Better IDE support - Autocomplete shows exactly what's available
+5. Easier onboarding - New developers understand code faster
+
+## Component Usage Example
+
+**Before (confusing):**
+```typescript
+// ViewerTopBar.tsx
+const currentCanvas = canvases?.[queryParamToArrayIndex(query.canvas)];
+const restricted = currentCanvas?.accessConditions?.some(
+  ac => ac.type === 'RestrictedAccess'
+);
+const imgSvc = currentCanvas?.imageServices?.[0];
+```
+
+**After (crystal clear):**
+```typescript
+// ViewerTopBar.refactored.tsx
+const { 
+  isCurrentCanvasRestricted,
+  hasIiifImageService,
+  canDownloadCurrentCanvas,
+} = useItemViewerContextV2();
+
+// Component just uses clear values - no calculations!
+```
+
+---
+
+**Next:** [04 - Test-First Approach](./04-test-first-approach.md)

--- a/rfcs/086-item-viewer-refactor/04-test-first-approach.md
+++ b/rfcs/086-item-viewer-refactor/04-test-first-approach.md
@@ -1,0 +1,106 @@
+# Test-First Methodology
+
+[← Back to Index](./README.md)
+
+**Strategy:** Write comprehensive automated tests BEFORE refactoring to lock in current behaviour. Manual testing is a supplementary safety net, not the primary verification method.
+
+## Why Automated Tests First?
+
+1. **Safety net** - Tests fail immediately if refactoring breaks something
+2. **Documentation** - Tests document current behaviour precisely
+3. **Confidence** - Can refactor aggressively knowing tests protect you
+4. **Regression prevention** - Future changes won't break existing behaviour
+5. **Faster feedback** - No need to manually click through every scenario
+6. **CI/CD integration** - Tests run automatically on every commit
+
+## Test-First Workflow
+
+For each phase:
+
+1. **Write automated tests FIRST** for current behaviour (characterisation tests)
+2. **Verify tests pass** with current implementation (establish baseline)
+3. **Make refactoring changes** to implementation
+4. **Tests should still pass** (green to green refactor)
+5. **Add new tests** for improved functionality if needed
+6. **(Optional) Run manual test checklist** for extra confidence
+
+## Test Coverage Requirements
+
+### Before Starting Any Phase
+
+**You MUST have automated tests covering:**
+
+- All derived boolean values (`isCurrentCanvasRestricted`, `hasMultipleCanvases`, etc.)
+- All navigation state (`isFirstCanvas`, `canNavigateNext`, etc.)
+- All edge cases (undefined canvas, empty manifest, restricted access, etc.)
+- Component integration (components actually read from context correctly)
+
+### Minimum Test Files Required
+
+For Phase 1 (Canvas Data), you need:
+
+1. **Context unit tests** - `ItemViewerContext.V2.test.tsx`
+   - Test all derived canvas data calculations
+   - Test all boolean flags
+   - Test edge cases (undefined, null, empty arrays)
+
+2. **Component integration tests** - `IIIFViewer.refactored.test.tsx`, `ViewerTopBar.refactored.test.tsx`
+   - Verify components consume context values
+   - Verify conditional rendering based on boolean flags
+   - Verify navigation state affects UI correctly
+
+3. **Mock utilities** - `test-utils.ts`
+   - Properly typed mock contexts
+   - Reusable test fixtures
+
+See [refactoring-iiif-viewer-context-testing.md](./refactoring-iiif-viewer-context-testing.md) for complete test examples with TypeScript types.
+
+## Test-First Benefits
+
+### What You Get
+
+- **Immediate feedback** - Know instantly if something breaks
+- **Refactoring confidence** - Change code fearlessly
+- **Living documentation** - Tests show how code should behave
+- **Onboarding tool** - New developers learn from tests
+- **CI/CD ready** - Automated verification on every push
+
+### What You Avoid
+
+- Manual testing every change
+- "Did I break something?" anxiety
+- Regression bugs shipping to production
+- Time-consuming QA cycles
+- Relying on memory for edge cases
+
+## When to Use Manual Testing
+
+Manual testing is **supplementary**, not primary. Use it to:
+
+1. **Verify visual appearance** - Automated tests don't check if UI looks right
+2. **Test interactions** - Complex user flows that are hard to automate
+3. **Cross-browser testing** - Ensure consistency across browsers
+4. **Extra confidence** - Double-check critical paths before release
+
+See [13-testing-strategy.md](./13-testing-strategy.md) for the complete manual testing checklist.
+
+## Red-Green-Refactor Cycle
+
+```
+1. RED    - Write failing test (or test for current behaviour)
+2. GREEN  - Make test pass with minimal code
+3. REFACTOR - Improve code while keeping tests green
+```
+
+For this refactoring, we're doing **GREEN to GREEN refactoring**:
+- Tests pass with current implementation (GREEN)
+- Refactor code
+- Tests still pass with new implementation (still GREEN)
+
+## Automated Test Examples
+
+See detailed examples in [refactoring-iiif-viewer-context-testing.md](./refactoring-iiif-viewer-context-testing.md).
+
+---
+
+**Next:** [05 - Feature Flag Strategy](./05-feature-flag-strategy.md)

--- a/rfcs/086-item-viewer-refactor/05-feature-flag-strategy.md
+++ b/rfcs/086-item-viewer-refactor/05-feature-flag-strategy.md
@@ -1,0 +1,110 @@
+# Feature Flag Strategy
+
+[← Back to Index](./README.md)
+
+**Approach:** Build refactored version alongside existing code, controlled by a feature flag. Load entirely different components based on toggle status rather than conditionals within components.
+
+## Why Feature Flag?
+
+1. **Safe rollout** - Users can opt in, test, provide feedback
+2. **Instant rollback** - Disable flag if issues arise (no deploy needed)
+3. **Production testing** - Validate with real traffic before making it the default
+4. **Clean code** - No conditionals littering components
+5. **Comparison** - Users can toggle between old/new to compare
+6. **Team confidence** - Ship changes knowing you can revert instantly
+
+## Component Structure
+
+```
+content/webapp/
+├── contexts/
+│   ├── ItemViewerContext/           # LEGACY - unchanged
+│   │   └── index.tsx
+│   └── ItemViewerContextV2/         # NEW - refactored version
+│       ├── index.tsx
+│       ├── ItemViewerContextV2.test.tsx
+│       └── test-utils.ts
+│
+├── views/pages/works/work/IIIFViewer/
+    ├── index.tsx                    # Wrapper - loads old OR new based on flag
+    ├── IIIFViewer.legacy.tsx        # Uses ItemViewerContext (old)
+    ├── IIIFViewer.refactored.tsx    # Uses ItemViewerContextV2 (new)
+    ├── ViewerTopBar.legacy.tsx
+    ├── ViewerTopBar.refactored.tsx
+    ├── ZoomedImage.legacy.tsx
+    ├── ZoomedImage.refactored.tsx
+    └── ...
+```
+
+**Key insight:** Legacy and refactored versions use different contexts entirely. This means:
+- Zero risk to existing implementation
+- Can develop new context in isolation
+- Can test both versions independently
+- Clean deletion when feature flag removed
+
+## Usage Pattern
+
+```typescript
+// content/webapp/views/pages/works/work/IIIFViewer/index.tsx
+import dynamic from 'next/dynamic';
+import { useToggles } from '@weco/toggles/webapp/hooks';
+import { IIIFViewerProps } from './types';
+
+// Important: dynamic() server-renders by default
+// Do NOT add { ssr: false } as this would break NoScriptImage functionality
+const IIIFViewerLegacy = dynamic(() => import('./IIIFViewer.legacy'));
+const IIIFViewerRefactored = dynamic(() => import('./IIIFViewer.refactored'));
+
+export default function IIIFViewer(props: IIIFViewerProps) {
+  const { iiifViewerRefactored } = useToggles();
+  
+  if (iiifViewerRefactored) {
+    return <IIIFViewerRefactored {...props} />;
+  }
+  
+  return <IIIFViewerLegacy {...props} />;
+}
+```
+
+## Flag Configuration
+
+**File:** `toggles/webapp/app/toggles.ts`
+
+```typescript
+export const toggles = {
+  // ... existing toggles ...
+  iiifViewerRefactored: {
+    id: 'iiifViewerRefactored',
+    title: 'IIIF Viewer - Refactored Context',
+    defaultValue: false, // Start disabled
+    description: 'Use refactored ItemViewerContext with centralised derived values',
+  },
+};
+```
+
+## Rollout Plan
+
+### Phase 1: Development
+- Feature flag OFF by default
+- Developers can enable for testing
+- All automated tests must pass with flag ON and OFF
+
+### Phase 2: Internal Testing
+- Enable for team members to verify functionality
+- Test with real data on staging/production
+
+### Phase 3: Default to ON
+- Make toggle publicly available
+- Continue monitoring
+
+### Phase 4: Cleanup
+- After toggle defaulting to ON for 1+ week with no issues
+- Remove feature flag entirely
+- Delete `.legacy.tsx` files
+- Rename `.refactored.tsx` to `.tsx`
+- Delete `ItemViewerContext` (old context)
+- Rename `ItemViewerContextV2` to `ItemViewerContext`
+
+---
+
+**Next:** [06 - Phase 0: Type Audit](./06-phase-0-type-audit.md)

--- a/rfcs/086-item-viewer-refactor/06-phase-0-type-audit.md
+++ b/rfcs/086-item-viewer-refactor/06-phase-0-type-audit.md
@@ -1,0 +1,229 @@
+# Phase 0: Type Audit and Cleanup
+
+Duration: 1-2 hours  
+Priority: Critical - Must complete before refactoring
+
+## Overview
+
+Before refactoring, audit and fix all types in the ItemViewer section to ensure type safety and catch errors early. Proper typing makes refactoring safer and easier to validate.
+
+## Findings from Actual Codebase
+
+### Types Are Mostly Good! 
+
+The ItemViewer section has mostly well-typed code:
+- All components have explicit prop types
+- Core types are well-defined in `content/webapp/types/manifest.ts` and `content/webapp/types/item-viewer.ts`
+- Most functions have proper return types
+- No widespread use of `any`
+
+### Already Using Official IIIF Types
+
+The codebase already uses the official IIIF Presentation 3.0 types:
+- Package: `@iiif/presentation-3` (v2.1.3)
+- Importing official types: `Manifest`, `Canvas`, `ContentResource`, `ChoiceBody`, `InternationalString`, etc.
+- Source: https://iiif.io/api/presentation/3.0/
+
+Custom types extend official types:
+```typescript
+// TransformedCanvas extends official IIIF Canvas structure
+export type TransformedCanvas = {
+  id: string;
+  type: NonNullable<ResourceType>;  // Uses official ResourceType
+  // ... adds Wellcome-specific transformations
+  painting: (ChoiceBody | ContentResource)[];  // Uses official types
+  metadata: MetadataItem[];  // Uses official MetadataItem
+};
+```
+
+This is best practice - use official types where available, extend for custom needs.
+
+### Issues Found
+
+#### 1. Implicit `any` in `setSearchResults` (2 locations)
+
+Problem:
+```typescript
+// content/webapp/contexts/ItemViewerContext/index.tsx
+setSearchResults: (v) => void;  // 'v' is implicitly 'any'
+
+// content/webapp/views/pages/works/work/IIIFViewer/IIIFViewer.tsx
+setSearchResults: (v) => void;  // 'v' is implicitly 'any'
+```
+
+Fix:
+```typescript
+setSearchResults: (v: SearchResults | null) => void;  // OK
+```
+
+#### 2. Missing Type Documentation for Common Patterns
+
+While types exist, several commonly-used patterns don't have named types:
+
+Pattern: Image Service Object
+```typescript
+// Used in multiple files (ZoomedImage.tsx, IIIFViewer.tsx)
+const mainImageService = { '@id': currentCanvas?.imageServiceId };
+```
+
+Recommendation: Add a named type for clarity:
+```typescript
+// content/webapp/types/item-viewer.ts
+export type ImageService = {
+  '@id': string | undefined;
+};
+```
+
+#### 3. Type Centralisation
+
+Types should live in predictable locations to avoid duplication and confusion:
+
+Current type locations:
+- IIIF-related types: `content/webapp/types/manifest.ts`
+- ItemViewer-specific types: `content/webapp/types/item-viewer.ts`
+- Catalogue API types: `content/webapp/services/wellcome/catalogue/types/`
+- Component-specific types: Defined near components when only used locally
+
+Principles for type centralisation:
+- Shared types used across multiple features belong in `content/webapp/types/`
+- API response types belong near their service in `content/webapp/services/`
+- Component-specific types can stay in component files if only used there
+- Don't duplicate types - import and reuse existing definitions
+- When unsure, check if a type already exists before creating a new one
+
+Check for type duplication:
+- Search for similar type names before adding new types
+- Look for inline type definitions that could use existing types
+- Consolidate multiple definitions of the same concept
+
+
+## Tasks
+
+### 1. Fix Implicit `any` Types
+
+Files to edit:
+- `content/webapp/contexts/ItemViewerContext/index.tsx`
+- `content/webapp/views/pages/works/work/IIIFViewer/IIIFViewer.tsx`
+
+Change:
+```diff
+- setSearchResults: (v) => void;
++ setSearchResults: (v: SearchResults | null) => void;
+```
+
+### 2. Add Missing Type Definitions (Optional but Recommended)
+
+File: `content/webapp/types/item-viewer.ts`
+
+Add type for image service pattern:
+
+```typescript
+import { Canvas, Manifest } from '@iiif/presentation-3';
+
+// Existing types (keep)
+export type CanvasRotatedImage = { canvas: number; rotation: number };
+
+export type ItemViewerQuery = {
+  canvas: number;
+  manifest: number;
+  query: string;
+  page: number;
+  shouldScrollToCanvas: boolean;
+};
+
+export type ParentManifest = Pick<Manifest, 'behavior'> & {
+  canvases: Pick<Canvas, 'id' | 'label'>[];
+};
+
+// NEW: Add image service type for common pattern
+export type ImageService = {
+  '@id': string | undefined;
+};
+```
+
+This makes the pattern explicit and easier to understand when refactoring.
+
+### 3. Document Existing Type Structure
+
+Before refactoring, understand what types are already available:
+
+Data Types:
+- `TransformedManifest` - `content/webapp/types/manifest.ts`
+- `TransformedCanvas` - `content/webapp/types/manifest.ts`
+- `WorkBasic` - `content/webapp/services/wellcome/catalogue/types/work.ts`
+- `Work` - `content/webapp/services/wellcome/catalogue/types/index.ts`
+- `SearchResults` - `@weco/content/services/iiif/types/search/v3`
+- `UiTree` - `@weco/content/views/pages/works/work/work.types`
+
+ItemViewer Types:
+- `CanvasRotatedImage` - `content/webapp/types/item-viewer.ts`
+- `ItemViewerQuery` - `content/webapp/types/item-viewer.ts`
+- `ParentManifest` - `content/webapp/types/item-viewer.ts`
+
+Context Type:
+- `Props` (ItemViewerContext) - `content/webapp/contexts/ItemViewerContext/index.tsx`
+
+### 4. Verify Component Prop Types
+
+Check these files have explicit prop types (they do, but verify):
+- `IIIFViewer.tsx` - `IIIFViewerProps`
+- `ViewerTopBar.tsx` - `ViewerTopBarProps`
+- `ZoomedImage.tsx` - `ZoomedImageProps`
+- `ImageViewer.tsx` - `ImageViewerProps`
+- `MainViewer.tsx` - component props defined inline
+
+All components checked have proper prop types.
+
+### 5. Run TypeScript Compiler
+
+```bash
+yarn tsc
+```
+
+Fix any errors that appear in `ItemViewer`/`IIIFViewer` files.
+
+### 6. Validate Against Official Specs
+
+Since you're using official IIIF types, verify your custom types align correctly and you're not duplicating them:
+
+Check IIIF Type Usage:
+Verified custom types properly use official `@iiif/presentation-3` types
+```typescript
+//  Good: Using official types directly
+import { Canvas, Manifest, ContentResource } from '@iiif/presentation-3';
+
+//  Good: Extending official types
+export type TransformedCanvas = {
+  // Uses official IIIF types as building blocks
+  painting: (ChoiceBody | ContentResource)[];
+  metadata: MetadataItem[];
+};
+
+//  Avoid: Redefining what IIIF already provides
+// Don't create your own Canvas type when @iiif/presentation-3 has one
+```
+
+#### Wellcome Catalogue API Types:
+
+Your Catalogue API types (`Work`, `WorkBasic`, `Item`, etc.) are manually defined. Consider centralising those types within the organisation.
+
+## Acceptance Criteria
+
+- [ ] Fixed both `setSearchResults` implicit `any` types
+- [ ] (Optional) Added `ImageService` type to `content/webapp/types/item-viewer.ts`
+- [ ] Documented existing type structure for reference
+- [ ] Checked for duplicate type definitions across files
+- [ ] `yarn tsc` runs without errors in ItemViewer files
+- [ ] All team members understand what types exist and where they live
+
+## What This Phase Achieves
+
+1. Type Safety - No implicit `any` in critical functions
+2. Official Types - Verified use of `@iiif/presentation-3` official IIIF types
+3. Documentation - Clear understanding of existing types and their sources
+4. Foundation - Solid base for refactoring with confidence
+5. Consistency - All types follow same patterns and use official specs where available
+
+## Next Steps
+
+**Next:** [Phase 1: Feature Flag Setup](./07-phase-1-feature-flag.md)

--- a/rfcs/086-item-viewer-refactor/07-phase-1-feature-flag.md
+++ b/rfcs/086-item-viewer-refactor/07-phase-1-feature-flag.md
@@ -1,0 +1,148 @@
+# Phase 1: Feature Flag Setup
+
+[← Back to Index](./README.md)
+
+**Effort:** 1 hour  
+**Risk:** None (no behaviour change)  
+**Priority:** Required after Phase 0 (Type Audit)  
+**Previous:** [Phase 0: Type Audit](./06-phase-0-type-audit.md)  
+**Next:** [Phase 2: Split MainViewer Components](./08-phase-2-split-components.md)  
+
+## Goal
+
+Set up infrastructure for safe refactoring using feature flags. At the end of this phase, you'll have two identical implementations (legacy and refactored) with the ability to toggle between them.
+
+## Prerequisites
+
+Complete [Phase 0: Type Audit](./06-phase-0-type-audit.md) first to ensure all types are correct before starting refactoring.
+
+## Steps
+
+### 0.1 Add Toggle Definition
+
+**File:** `toggles/webapp/app/toggles.ts`
+
+```typescript
+export const toggles = {
+  // ... existing toggles ...
+  iiifViewerRefactored: {
+    id: 'iiifViewerRefactored',
+    title: 'IIIF Viewer - Refactored',
+    defaultValue: false, 
+    description: 'Use refactored Item Viewer',
+  },
+};
+```
+
+### 0.2 Create New Context Structure
+Create new context directory as `content/webapp/contexts/ItemViewerContextV2/index.tsx` by copying `content/webapp/contexts/ItemViewerContext/index.tsx`.
+
+### 0.3 Rename Existing Components to .legacy.tsx
+
+```bash
+cd content/webapp/views/pages/works/work/IIIFViewer
+
+# Rename main files
+mv IIIFViewer.tsx IIIFViewer.legacy.tsx
+mv ViewerTopBar.tsx ViewerTopBar.legacy.tsx
+mv ZoomedImage.tsx ZoomedImage.legacy.tsx
+mv MainViewer.tsx MainViewer.legacy.tsx
+```
+
+### 0.4 Create Wrapper Component
+
+**New file:** `content/webapp/views/pages/works/work/IIIFViewer/index.tsx`
+
+```typescript
+import dynamic from 'next/dynamic';
+import { useToggles } from '@weco/toggles/webapp/hooks';
+import { IIIFViewerProps } from './types';
+
+// Note: dynamic() server-renders by default (ssr: true is implicit)
+// This preserves NoScriptImage functionality for users without JavaScript
+const IIIFViewerLegacy = dynamic(() => import('./IIIFViewer.legacy'));
+const IIIFViewerRefactored = dynamic(() => import('./IIIFViewer.refactored'));
+
+export default function IIIFViewer(props: IIIFViewerProps) {
+  const { iiifViewerRefactored } = useToggles();
+  
+  if (iiifViewerRefactored) {
+    return <IIIFViewerRefactored {...props} />;
+  }
+  
+  return <IIIFViewerLegacy {...props} />;
+}
+```
+
+**Important:** 
+- Legacy components import `ItemViewerContext`, refactored components import `ItemViewerContextV2`
+- Dynamic imports are server-rendered by default - `NoScriptImage` will still work without JavaScript
+- Do NOT add `{ ssr: false }` to the dynamic imports as this would break progressive enhancement
+
+### 0.5 Create Initial .refactored.tsx Files
+
+Copy legacy files to create refactored versions:
+
+```bash
+cd content/webapp/views/pages/works/work/IIIFViewer
+
+# Create refactored versions
+cp IIIFViewer.legacy.tsx IIIFViewer.refactored.tsx
+cp ViewerTopBar.legacy.tsx ViewerTopBar.refactored.tsx
+cp ZoomedImage.legacy.tsx ZoomedImage.refactored.tsx
+cp MainViewer.legacy.tsx MainViewer.refactored.tsx
+```
+
+Update imports in `.refactored.tsx` files:
+
+```typescript
+// OLD (in .legacy.tsx files):
+import ItemViewerContext from '@weco/common/contexts/ItemViewerContext';
+
+// NEW (in .refactored.tsx files):
+import ItemViewerContextV2 from '@weco/common/contexts/ItemViewerContextV2';
+```
+
+### 0.6 Verify No Behaviour Change
+
+**Critical:** At this stage, both implementations should be identical.
+
+1. Run: `yarn content`
+2. Test viewer on localhost with flag OFF (should use legacy)
+3. Enable toggle in toggles dashboard: `/toggles`
+4. Test viewer with flag ON (should use refactored - identical behaviour)
+5. Confirm toggling between old/new works seamlessly
+
+**Test scenarios:**
+- Navigate between canvases (thumbnails, arrows)
+- Toggle sidebar
+- Zoom in/out
+- Fullscreen mode
+- Download options
+- Restricted items
+
+**Checkpoint:** No user-facing behaviour has changed. You've set up infrastructure with two identical implementations using different contexts.
+
+## Success Criteria
+
+- [ ] Feature flag defined in `toggles.ts`
+- [ ] ItemViewerContextV2 created (identical to ItemViewerContext)
+- [ ] All original components renamed to `.legacy.tsx`
+- [ ] Wrapper component loads legacy or refactored based on flag
+- [ ] All `.refactored.tsx` files created and import ItemViewerContextV2
+- [ ] Application runs with flag OFF (uses legacy)
+- [ ] Application runs with flag ON (uses refactored, identical behaviour)
+- [ ] No TypeScript errors
+- [ ] No console warnings
+
+## Next Steps
+
+Once Phase 1 is complete and verified, proceed to:
+
+**[Phase 2: Split MainViewer Components](./08-phase-2-split-components.md)** - Split MainViewer before context refactoring (cleaner architecture)
+
+---
+
+**See also:**
+- [Migration Checklist](./13-migration-checklist.md) - Detailed verification steps
+- [Feature Flag Strategy](./05-feature-flag-strategy.md) - Why we use feature flags

--- a/rfcs/086-item-viewer-refactor/08-phase-2-split-components.md
+++ b/rfcs/086-item-viewer-refactor/08-phase-2-split-components.md
@@ -1,0 +1,242 @@
+# Phase 2: Split MainViewer Components
+
+[← Back to Index](./README.md)
+
+**Effort:** 3-4 hours  
+**Risk:** Low (isolated change, easy to test)  
+**Priority:** Required before context refactoring  
+**Previous:** [Phase 1: Feature Flag Setup](./07-phase-1-feature-flag.md)  
+**Next:** [Phase 3: Canvas Data](./09-phase-3-canvas-data.md)  
+
+## Goal
+
+Split `MainViewer` into separate components for different viewing modes before refactoring the context. This simplifies the context work by allowing each viewer mode to consume only the values it needs.
+
+## Why Do This First?
+
+Component splitting should happen **before** the main context refactoring because:
+
+1. **Simpler context design**: Each viewer type can consume exactly the context values it needs
+2. **Clearer testing**: Test each viewer mode independently with focused test suites
+3. **Easier refactoring**: Norming context values is simpler when components aren't juggling multiple modes
+4. **Better architecture**: Fixes architectural debt before building on top of it
+
+## Problem: MainViewer Has Two Faces
+
+`MainViewer.tsx` has two fundamentally different implementations:
+
+```typescript
+if (hasOnlyRenderableImages) {
+  // Mode A: Virtualized image scrolling with FixedSizeList
+  return <FixedSizeList>{ItemRenderer}</FixedSizeList>;
+}
+
+// Mode B: Direct item rendering with IIIFItem components
+return <>{displayItems.map(item => <IIIFItem />)}</>;
+```
+
+These are two different components with:
+- Different data requirements
+- Different performance characteristics  
+- Different rendering strategies
+- Different testing needs
+
+This violates the Single Responsibility Principle and makes the code harder to maintain and test.
+
+## Solution: Split into Separate Components
+
+**Before:**
+```
+MainViewer
+  ├── if (hasOnlyRenderableImages) { FixedSizeList logic }
+  └── else { IIIFItem rendering }
+```
+
+**After:**
+```
+MainViewer (router component)
+  ├── VirtualizedImageViewer (for image-only works)
+  └── PaginatedItemViewer (for mixed content/archives)
+```
+
+**Benefits:**
+- **Clarity:** Each component has one clear purpose
+- **Testability:** Test each mode independently
+- **Performance:** Separate bundle chunks, load only what's needed
+- **Maintainability:** Changes to one mode don't affect the other
+- **Type safety:** Each component has its own specific props
+- **Context refactoring:** Each viewer can consume only what it needs
+
+## Implementation Steps
+
+### 2.1 Create VirtualizedImageViewer.tsx
+
+Extract the image-only virtualized scrolling logic into its own component.
+
+**New file:** `content/webapp/views/pages/works/work/IIIFViewer/VirtualizedImageViewer.tsx`
+
+```typescript
+// Only handles image-only works with virtualized scrolling
+import { FunctionComponent } from 'react';
+import { FixedSizeList } from 'react-window';
+import { useItemViewerContext } from '@weco/content/contexts/ItemViewerContext';
+
+const VirtualizedImageViewer: FunctionComponent = () => {
+  const {
+    mainAreaWidth,
+    mainAreaHeight,
+    canvases,
+    rotatedImages,
+    // ... only props needed for this mode
+  } = useItemViewerContext();
+  
+  return (
+    <FixedSizeList
+      width={mainAreaWidth}
+      height={mainAreaHeight}
+      itemCount={canvases?.length || 0}
+      // ... virtualization logic (copy from MainViewer)
+    >
+      {ItemRenderer}
+    </FixedSizeList>
+  );
+};
+
+export default VirtualizedImageViewer;
+```
+
+### 2.2 Create PaginatedItemViewer.tsx
+
+Extract the mixed content and archive rendering logic into its own component.
+
+**New file:** `content/webapp/views/pages/works/work/IIIFViewer/PaginatedItemViewer.tsx`
+
+```typescript
+// Only handles mixed content and archives
+import { FunctionComponent } from 'react';
+import { useItemViewerContext } from '@weco/content/contexts/ItemViewerContext';
+import IIIFItem from './IIIFItem';
+
+const PaginatedItemViewer: FunctionComponent = () => {
+  const {
+    currentCanvas,
+    canvases,
+    canvas,
+    // ... only props needed for this mode
+  } = useItemViewerContext();
+  
+  const displayItems = currentCanvas ? getDisplayItems(currentCanvas) : [];
+  
+  return (
+    <>
+      {displayItems.map((item, i) => (
+        <IIIFItem
+          key={i}
+          item={item}
+          canvas={currentCanvas}
+          // ... item rendering (copy from MainViewer)
+        />
+      ))}
+    </>
+  );
+};
+
+export default PaginatedItemViewer;
+```
+
+### 2.3 Update MainViewer to Router Component
+
+Convert `MainViewer.tsx` into a simple router that chooses which implementation to render.
+
+**File:** `content/webapp/views/pages/works/work/IIIFViewer/MainViewer.tsx`
+
+```typescript
+import { FunctionComponent } from 'react';
+import { useItemViewerContext } from '@weco/content/contexts/ItemViewerContext';
+
+// Import both viewer implementations
+import VirtualizedImageViewer from './VirtualizedImageViewer';
+import PaginatedItemViewer from './PaginatedItemViewer';
+
+const MainViewer: FunctionComponent = () => {
+  const { hasOnlyRenderableImages } = useItemViewerContext();
+  
+  // Router component: decide which implementation to use
+  if (hasOnlyRenderableImages) {
+    return <VirtualizedImageViewer />;
+  }
+  
+  return <PaginatedItemViewer />;
+};
+
+export default MainViewer;
+```
+
+### 2.4 Write Tests for Each Component
+
+Create separate test files for each viewer type:
+
+**Tests:**
+- `VirtualizedImageViewer.test.tsx` - Test virtualized scrolling behavior
+- `PaginatedItemViewer.test.tsx` - Test paginated rendering behavior
+- `MainViewer.test.tsx` - Test routing logic
+
+### 2.5 Verify No Regressions
+
+Run existing E2E tests to ensure behavior hasn't changed:
+- Image-only works still render correctly
+- Archive works still render correctly
+- Mixed content works still render correctly
+
+## Testing Checklist
+
+- [ ] VirtualizedImageViewer renders image-only works correctly
+- [ ] PaginatedItemViewer renders archive/mixed content correctly
+- [ ] MainViewer routes to correct implementation based on `hasOnlyRenderableImages`
+- [ ] All E2E tests pass
+- [ ] No visual regressions
+- [ ] No console errors
+- [ ] Bundle size hasn't increased significantly
+
+## Other Candidates for Splitting (Future Work)
+
+After this phase, consider splitting other components with multiple modes:
+
+**Look for these patterns:**
+- Large if/else blocks returning different JSX
+- Components with multiple "modes" or "types"
+- Boolean props that drastically change behaviour
+- Different event handlers based on conditionals
+
+**Potential candidates:**
+- `IIIFViewer.tsx` - different rendering for image-only vs mixed content
+- Any component checking `hasOnlyRenderableImages` extensively
+
+**When NOT to split:**
+- Just conditional rendering of small UI elements (buttons, labels)
+- The modes share significant logic
+- Conditional is for progressive enhancement (browser support)
+- Splitting would create more complexity than it solves
+
+## Success Criteria
+
+- [ ] `MainViewer` is a simple router (<20 lines)
+- [ ] `VirtualizedImageViewer` handles only image-only works
+- [ ] `PaginatedItemViewer` handles only mixed/archive works
+- [ ] All tests pass
+- [ ] No behavioral changes detected
+- [ ] Code is easier to understand and test
+
+## Time Estimate
+
+- Extract VirtualizedImageViewer: 1 hour
+- Extract PaginatedItemViewer: 1 hour
+- Convert MainViewer to router: 30 minutes
+- Write/update tests: 1 hour
+- Test and verify: 30 minutes
+
+**Total: 3-4 hours**
+
+---
+
+**Next:** [Phase 3: Canvas Data Context](./09-phase-3-canvas-data.md)

--- a/rfcs/086-item-viewer-refactor/09-phase-3-canvas-data.md
+++ b/rfcs/086-item-viewer-refactor/09-phase-3-canvas-data.md
@@ -1,0 +1,178 @@
+# Phase 3: Canvas Data to Context
+
+[← Back to Index](./README.md)
+
+**Effort:** 3 hours (tests) + 3-4 hours (refactoring) = **6-7 hours total**  
+**Risk:** Low (tests prevent regressions)  
+**Priority:** High (foundation for other phases)  
+**Previous:** [Phase 2: Split MainViewer Components](./08-phase-2-split-components.md)  
+**Next:** [Phase 4: Download Logic](./10-phase-4-download-logic.md)  
+
+## Goal
+
+Add derived canvas data and boolean flags that are used by multiple components to `ItemViewerContextV2`. Components read these values instead of calculating them independently.
+
+**Decision criteria:** Only add to context if:
+1. Value is calculated in 2+ components (eliminates duplication), OR
+2. Value will likely be needed by multiple components soon (e.g., `isCurrentCanvasRestricted` for download restrictions)
+
+**Note:** Download logic stays OUT of context (goes to a hook instead) because it's only used in `ViewerTopBar`.
+
+## Critical: Automated Tests FIRST
+
+**Before writing any implementation code, you MUST:**
+
+1. Write comprehensive automated tests for all derived values
+2. Verify tests pass with current implementation
+3. Then and only then make refactoring changes
+
+See [refactoring-iiif-viewer-context-testing.md](./refactoring-iiif-viewer-context-testing.md) for complete test examples with TypeScript types.
+
+## Steps Overview
+
+### 1.1 Write Characterisation Tests FIRST (3 hours)
+
+**Files to create:**
+- `content/webapp/contexts/ItemViewerContextV2/ItemViewerContextV2.test.tsx` - Context unit tests
+- `content/webapp/contexts/ItemViewerContextV2/test-utils.ts` - Properly typed mocks
+- `content/webapp/views/pages/works/work/IIIFViewer/IIIFViewer.refactored.test.tsx` - Integration tests
+- `content/webapp/views/pages/works/work/IIIFViewer/ViewerTopBar.refactored.test.tsx` - Component tests
+
+**Test coverage required:**
+- All derived canvas data (`currentCanvas`, `currentCanvasIndex`, `mainImageService`)
+- All boolean flags (`hasMultipleCanvases`, `isFirstCanvas`, `canNavigateNext`, etc.)
+- All edge cases (undefined manifest, empty canvases, invalid index)
+- Component integration (verify components consume context)
+
+See [Testing Guide](./refactoring-iiif-viewer-context-testing.md) for complete examples.
+
+### 1.2 Make Tests Pass (Implementation)
+
+Once tests are written, add the derived values to `IIIFViewer.refactored.tsx`:
+
+```typescript
+// Derived canvas data
+const currentCanvasIndex = queryParamToArrayIndex(canvas);
+const currentCanvas = transformedManifest?.canvases[currentCanvasIndex];
+const totalCanvases = transformedManifest?.canvases?.length || 0;
+
+// Canvas-related booleans (crystal clear!)
+const hasMultipleCanvases = totalCanvases > 1;
+const isFirstCanvas = currentCanvasIndex === 0;
+const isLastCanvas = currentCanvasIndex === totalCanvases - 1;
+const canNavigateNext = !isLastCanvas && hasMultipleCanvases;
+const canNavigatePrevious = !isFirstCanvas && hasMultipleCanvases;
+const isCurrentCanvasRestricted = currentCanvas 
+  ? hasRestrictedItem(currentCanvas)  // Use helper from restricted-images merge
+  : false;
+
+// Image service data
+const mainImageService = { '@id': currentCanvas?.imageServiceId || '' };
+const hasIiifImageService = Boolean(currentCanvas?.imageServiceId);
+
+// Probe service data (added in restricted-images merge)
+// Note: Probe state itself stays in useIIIFProbeService hook (used in 2 places)
+// Only add probeServiceId if other components need it beyond the hook
+const currentProbeServiceId = currentCanvas?.probeServiceId;
+
+// Add to context provider
+<ItemViewerContextV2.Provider value={{
+  // ... existing ...
+  currentCanvasIndex,
+  currentCanvas,
+  mainImageService,
+  hasMultipleCanvases,
+  isFirstCanvas,
+  isLastCanvas,
+  canNavigateNext,
+  canNavigatePrevious,
+  isCurrentCanvasRestricted,
+  hasIiifImageService,
+  // Optionally add if needed by multiple components:
+  // currentProbeServiceId,
+}}>
+```
+
+**Note on probe service:** The `restricted-images` merge added `probeServiceId` to `TransformedCanvas` and a `useIIIFProbeService` hook. The hook handles probe polling state internally. Only add `currentProbeServiceId` to context if components beyond `MainViewer` and `ItemWrapper` need it.
+
+### 1.3 Update `ItemViewerContextV2` Types
+
+Add all new props to the TypeScript interface with clear types.
+
+### 1.4 Update Components to Use Context
+
+**`ViewerTopBar.refactored.tsx`** - Remove local calculations, use context:
+```typescript
+const {
+  currentCanvas,
+  isCurrentCanvasRestricted,
+  canNavigateNext,
+  canNavigatePrevious,
+} = useItemViewerContextV2();
+
+// Delete all local currentCanvas calculations
+// Use values directly from context
+```
+
+**`ZoomedImage.refactored.tsx`** - Use `currentCanvas` and `mainImageService` from context
+
+**`MainViewer.refactored.tsx`** - Use `currentCanvas` from context
+
+**Styled components** - Use `hasMultipleCanvases` from context
+
+### 1.5 Run Automated Tests
+
+```bash
+yarn test ItemViewerContextV2.test
+yarn test IIIFViewer.refactored
+yarn test ViewerTopBar.refactored
+```
+
+All tests should pass.
+
+### 1.6 (Optional) Manual Testing
+
+See [13-testing-strategy.md](./13-testing-strategy.md) for comprehensive manual testing checklist.
+
+**Quick smoke tests:**
+- [ ] Viewer loads correctly
+- [ ] Navigate between canvases
+- [ ] Toggle sidebar/grid
+- [ ] Verify download options appear
+
+## Why Crystal-Clear Boolean Naming Matters
+
+**Before (confusing):**
+```typescript
+const hasNext = idx < canvases.length - 1 && canvases.length > 1;
+<NextButton disabled={!hasNext} />
+```
+
+**After (crystal clear):**
+```typescript
+const { canNavigateNext } = useItemViewerContextV2();
+<NextButton disabled={!canNavigateNext} />
+```
+
+Self-documenting code! No mental gymnastics required.
+
+## Success Criteria
+
+- [ ] All automated tests pass (context + components)
+- [ ] TypeScript compiles with no errors
+- [ ] Components use context values (not calculating locally)
+- [ ] Feature flag toggle works (old vs new identical behaviour)
+- [ ] Manual testing checklist complete (optional)
+
+## Time Breakdown
+
+- 3 hours: Write comprehensive automated tests
+- 2 hours: Add derived values to context
+- 1-2 hours: Update components to use context
+- 30 mins: Run tests and verify
+
+Total: 6-7 hours
+
+---
+
+**Next:** [Phase 4: Download Logic](./10-phase-4-download-logic.md)

--- a/rfcs/086-item-viewer-refactor/10-phase-4-download-logic.md
+++ b/rfcs/086-item-viewer-refactor/10-phase-4-download-logic.md
@@ -1,0 +1,173 @@
+# Phase 4: Download Logic Hook
+
+[← Back to Index](./README.md)
+
+**Effort:** 2 hours (tests) + 2 hours (implementation) = **4 hours total**  
+**Risk:** Medium (mitigated by tests)  
+**Priority:** Medium  
+**Previous:** [Phase 3: Canvas Data](./09-phase-3-canvas-data.md)  
+**Next:** [Phase 5: Restriction Status](./11-phase-5-restriction-status.md)  
+
+## Goal
+
+Extract download options logic from `ViewerTopBar.tsx` into a reusable custom hook. This removes ~65 lines of complex business logic from the component and makes it testable in isolation.
+
+**Note:** The `restricted-images` merge already added download deduplication and improved ChoiceBody handling. This phase integrates those changes into the hook.
+
+## Why Extract to a Hook (Not Context)?
+
+**Current problem:** `ViewerTopBar.tsx` has 65+ lines of download option calculations:
+- IIIF image downloads
+- Canvas image downloads from services
+- Canvas rendering downloads (PDFs)
+- Manifest downloads
+- Video/audio downloads
+- ChoiceBody handling
+
+**Why a hook instead of context?**
+- Not for context: Only used in `ViewerTopBar` (one component)
+- Perfect for hook: Complex logic (65 lines) worth extracting for testability
+- Potentially reusable: Other components might need download options in the future
+
+**Solution:** Move all this into `useDownloadOptions` hook:
+- Easier to test (no component rendering needed)
+- Reusable if other components need download options
+- Clearer component code (`ViewerTopBar` focuses on presentation)
+- Business logic separate from presentation
+
+## Steps
+
+### 2.1 Write Tests FIRST for `useDownloadOptions` Hook
+
+**File:** `content/webapp/hooks/useDownloadOptions.test.ts`
+
+```typescript
+describe('useDownloadOptions', () => {
+  it('should return empty array when no canvas or manifest', () => { ... });
+  it('should include IIIF image download options', () => { ... });
+  it('should include canvas image downloads from services', () => { ... });
+  it('should include canvas rendering downloads (PDFs)', () => { ... });
+  it('should include manifest-level downloads', () => { ... });
+  it('should include video/audio downloads', () => { ... });
+  it('should handle ChoiceBody items correctly', () => { ... });
+  it('should deduplicate downloads with same id', () => { ... });  // NEW from restricted-images
+  it('should memoise results and only recalculate when dependencies change', () => { ... });
+});
+
+describe('useImageServices', () => {
+  it('should extract image services from canvas painting', () => { ... });
+  it('should return empty array when no painting items', () => { ... });
+  it('should handle undefined currentCanvas', () => { ... });
+});
+```
+
+### 2.2 Create `useDownloadOptions` Hook
+
+**File:** `content/webapp/hooks/useDownloadOptions.ts`
+
+```typescript
+export function useDownloadOptions(iiifImageLocation?: DigitalLocation) {
+  const { work, currentCanvas, transformedManifest } = useItemViewerContext();
+  const transformedIIIFImage = useTransformedIIIFImage(work);
+
+  return useMemo(() => {
+    // Extract image services
+    const imageServices = /* ... */;
+    
+    // Calculate all download options
+    const iiifImageDownloadOptions = /* ... */;
+    const canvasImageDownloads = /* ... */;
+    const canvasDownloadOptions = /* ... */;
+    const manifestDownloadOptions = /* ... */;
+    const videoAudioDownloadOptions = /* ... */;
+
+    // Combine all options
+    const allOptions = [
+      ...iiifImageDownloadOptions,
+      ...canvasImageDownloads,
+      ...canvasDownloadOptions,
+      ...manifestDownloadOptions,
+      ...videoAudioDownloadOptions,
+    ];
+
+    // Deduplicate by download URL (id)
+    // Added in restricted-images merge - prevents same file appearing multiple times
+    // when it's available from multiple sources in the IIIF manifest
+    return allOptions.filter(
+      (option, index, self) => 
+        self.findIndex(o => o.id === option.id) === index
+    );
+  }, [currentCanvas, transformedManifest, iiifImageLocation, /* ... */]);
+}
+```
+
+**Note:** The `restricted-images` merge improved `getDownloadOptionsFromCanvasRenderingAndSupplementing` to properly handle ChoiceBody items:
+
+```typescript
+// In utils/iiif/v3/index.ts (already implemented)
+export function getDownloadOptionsFromCanvasRenderingAndSupplementing(
+  canvas: TransformedCanvas
+): DownloadOption[] {
+  return [...canvas.rendering, ...canvas.supplementing]
+    .flatMap(item => (isChoiceBody(item) ? item.items : [item]))
+    .filter((item): item is ContentResource => typeof item !== 'string')
+    .map(convertToDownloadOption);
+}
+```
+
+### 2.3 Update `ViewerTopBar` to Use Hook
+
+**File:** `content/webapp/views/pages/works/work/IIIFViewer/ViewerTopBar.refactored.tsx`
+
+```typescript
+// ADD import:
+import { useDownloadOptions } from '@weco/content/hooks/useDownloadOptions';
+
+// DELETE lines 226-291 (all download calculation logic)
+
+// REPLACE with:
+const downloadOptions = useDownloadOptions(iiifImageLocation);
+```
+
+Result: ~65 lines removed from `ViewerTopBar`.
+
+### 2.4 Run Tests
+
+```bash
+yarn test useDownloadOptions.test
+yarn test ViewerTopBar.refactored.test
+```
+
+All should pass.
+
+### 2.5 Manual Testing
+
+- [ ] Download dropdown appears
+- [ ] All download options present:
+  - [ ] IIIF image downloads (various sizes)
+  - [ ] Canvas image downloads
+  - [ ] PDF downloads (if applicable)
+  - [ ] Manifest downloads (if applicable)
+  - [ ] Video/audio downloads (if applicable)
+- [ ] Download links work correctly
+- [ ] Options update when navigating between canvases
+
+## Success Criteria
+
+- [ ] Tests for `useDownloadOptions` pass
+- [ ] `ViewerTopBar` ~65 lines shorter
+- [ ] Download dropdown still works identically
+- [ ] All download types still appear correctly
+
+## Time Breakdown
+
+- 2 hours: Write comprehensive tests for hook
+- 1 hour: Extract logic to hook
+- 1 hour: Update ViewerTopBar to use hook
+- 30 mins: Manual testing
+
+Total: ~4 hours
+
+---
+
+**Next:** [Phase 5: Restriction Status](./11-phase-5-restriction-status.md)

--- a/rfcs/086-item-viewer-refactor/11-phase-5-restriction-status.md
+++ b/rfcs/086-item-viewer-refactor/11-phase-5-restriction-status.md
@@ -1,0 +1,80 @@
+# Phase 5: Restriction Status
+
+[← Back to Index](./README.md)
+
+**Effort:** 1 hour  
+**Risk:** Low  
+**Priority:** Low  
+**Previous:** [Phase 4: Download Logic](./10-phase-4-download-logic.md)  
+**Next:** [Phase 6: Duplicate Index Calls](./12-phase-6-duplicate-calls.md)  
+
+## Goal
+
+Add `isCurrentCanvasRestricted` to context instead of calculating it in `ViewerTopBar`.
+
+## Why?
+
+- `ViewerTopBar` calculates this value
+- Other components might need it too
+- Centralise restriction logic in one place
+- Clear boolean name makes intent obvious
+
+**Note:** The `restricted-images` merge added the canonical `hasRestrictedItem()` helper that should be used for all restriction checks.
+
+## Steps
+
+### 3.1 Add to Context Type
+
+**File:** `content/webapp/contexts/ItemViewerContextV2/index.tsx`
+
+```typescript
+type Props = {
+  // ... existing ...
+  isCurrentCanvasRestricted: boolean;  // Current canvas has restricted access
+};
+```
+
+### 3.2 Calculate in `IIIFViewer.refactored.tsx`
+
+```typescript
+const isCurrentCanvasRestricted = currentCanvas 
+  ? hasRestrictedItem(currentCanvas) 
+  : false;
+
+<ItemViewerContextV2.Provider value={{
+  // ... existing ...
+  isCurrentCanvasRestricted,
+}}>
+```
+
+### 3.3 Update `ViewerTopBar.refactored.tsx`
+
+```typescript
+// REMOVE:
+const isRestricted = currentCanvas && hasRestrictedItem(currentCanvas);
+
+// ADD to destructuring:
+const { isCurrentCanvasRestricted } = useItemViewerContextV2();
+
+// UPDATE usage:
+- {isRestricted && <RestrictedBadge />}
++ {isCurrentCanvasRestricted && <RestrictedBadge />}
+```
+
+## Testing
+
+- [ ] Restricted badge appears on restricted canvases
+- [ ] Badge doesn't appear on unrestricted canvases
+- [ ] Download options respect restriction status
+
+## Success Criteria
+
+- [ ] `isCurrentCanvasRestricted` in context
+- [ ] `ViewerTopBar` uses context value
+- [ ] Restricted badge appears correctly
+
+## Time: ~1 hour
+
+---
+
+**Next:** [Phase 6: Duplicate Index Calls](./12-phase-6-duplicate-calls.md)

--- a/rfcs/086-item-viewer-refactor/12-phase-6-duplicate-calls.md
+++ b/rfcs/086-item-viewer-refactor/12-phase-6-duplicate-calls.md
@@ -1,0 +1,84 @@
+# Phase 6: Eliminate Duplicate Index Calls
+
+[← Back to Index](./README.md)
+
+**Effort:** 30 minutes  
+**Risk:** Low  
+**Priority:** Medium  
+**Previous:** [Phase 5: Restriction Status](./11-phase-5-restriction-status.md)  
+**Next:** [Phase 7: Cleanup](./13-phase-7-cleanup.md)  
+
+## Goal
+
+Since `currentCanvasIndex` is now in context (from Phase 1), remove all duplicate `queryParamToArrayIndex(query.canvas)` calls across components.
+
+## Why?
+
+**Before:**
+```typescript
+// Thumbnails.tsx
+const index = queryParamToArrayIndex(query.canvas);
+
+// NoScriptImage.tsx
+const index = queryParamToArrayIndex(query.canvas);
+
+// MultipleManifestList.tsx
+const index = queryParamToArrayIndex(query.canvas);
+```
+
+**Problem:** Same calculation repeated in 3+ files.
+
+**After:**
+```typescript
+const { currentCanvasIndex } = useItemViewerContextV2();
+```
+
+Single source of truth!
+
+## Files to Update
+
+Find all occurrences:
+
+```bash
+cd content/webapp
+grep -r "queryParamToArrayIndex(query.canvas)" .
+```
+
+### Expected files (update each):
+
+1. **`Thumbnails.tsx`** (lines 38, 49)
+2. **`NoScriptImage.tsx`** (line 42)
+3. **`MultipleManifestList.tsx`** (lines 23, 37)
+4. Any others found
+
+### Replace pattern:
+
+```typescript
+// OLD:
+const index = queryParamToArrayIndex(query.canvas);
+// or
+queryParamToArrayIndex(query.canvas)
+
+// NEW:
+const { currentCanvasIndex } = useItemViewerContextV2();
+// or just use currentCanvasIndex directly
+```
+
+## Testing
+
+- [ ] Thumbnails highlight correct canvas
+- [ ] NoScript image shows correct canvas
+- [ ] Multiple manifest list shows correct position
+- [ ] All components that use index still work
+
+## Success Criteria
+
+- [ ] No more `queryParamToArrayIndex(query.canvas)` calls in consuming components
+- [ ] All components use `currentCanvasIndex` from context
+- [ ] Test coverage maintained
+
+## Time: ~30 minutes
+
+---
+
+**Next:** [Phase 7: Cleanup](./13-phase-7-cleanup.md)

--- a/rfcs/086-item-viewer-refactor/13-migration-checklist.md
+++ b/rfcs/086-item-viewer-refactor/13-migration-checklist.md
@@ -1,0 +1,241 @@
+# Migration Checklist
+
+[← Back to Index](./README.md)
+
+This checklist helps you track progress through each phase. Check off items as you complete them.
+
+## Before Starting
+
+- [ ] Create feature branch: `refactor/iiif-viewer-context`
+- [ ] Ensure all tests pass on main branch
+- [ ] Read through all phase documents
+- [ ] Understand the test-first workflow
+
+---
+
+## Phase 0: Type Audit and Cleanup
+
+Duration: 1-1.5 hours
+
+- [ ] Fix `setSearchResults: (v) => void` to `setSearchResults: (v: SearchResults | null) => void` in:
+  - [ ] `content/webapp/contexts/ItemViewerContext/index.tsx`
+  - [ ] `content/webapp/views/pages/works/work/IIIFViewer/IIIFViewer.tsx`
+- [ ] (Optional) Add `ImageService` type to `content/webapp/types/item-viewer.ts`
+- [ ] Document existing type structure in Phase 0 doc
+- [ ] Verify custom types properly use `@iiif/presentation-3` official types
+- [ ] (Optional) Check if Catalogue API has OpenAPI spec at https://developers.wellcomecollection.org/api/catalogue
+- [ ] Run `yarn tsc`
+- [ ] Verify no TypeScript errors in ItemViewer files
+- [ ] Commit type fixes
+
+**Time checkpoint:** Should take 1-1.5 hours
+
+---
+
+## Phase 1: Feature Flag Setup
+
+**Duration: 1 hour**
+
+- [ ] Add `iiifViewerRefactored` toggle definition in `toggles/webapp/app/toggles.ts`
+- [ ] Create `content/webapp/contexts/ItemViewerContextV2` directory
+- [ ] Copy ItemViewerContext to ItemViewerContextV2
+- [ ] Rename all component files to `.legacy.tsx`
+- [ ] Create wrapper component `index.tsx` that switches based on flag
+- [ ] Create `.refactored.tsx` files (copies of legacy)
+- [ ] Update `.refactored.tsx` imports to use ItemViewerContextV2
+- [ ] Run `yarn content` - application starts
+- [ ] Test with flag OFF - uses legacy
+- [ ] Test with flag ON - uses refactored (identical to legacy)
+- [ ] No TypeScript errors
+- [ ] No console warnings
+
+**Time checkpoint:** Should take ~1 hour
+
+---
+
+## Phase 2: Split MainViewer Components
+
+**Duration: 3-4 hours**
+
+- [ ] Create `VirtualizedImageViewer.tsx` (extract from MainViewer)
+- [ ] Create `PaginatedItemViewer.tsx` (extract from MainViewer)
+- [ ] Update `MainViewer.tsx` to be simple router component
+- [ ] Write tests for `VirtualizedImageViewer.test.tsx`
+- [ ] Write tests for `PaginatedItemViewer.test.tsx`
+- [ ] Write tests for `MainViewer.test.tsx` (routing logic)
+- [ ] Verify image-only works still render correctly
+- [ ] Verify archive works still render correctly
+- [ ] No regression in E2E tests
+- [ ] No console errors
+- [ ] Bundle size hasn't increased significantly
+
+**Time checkpoint:** Should take ~3-4 hours
+
+---
+
+## Phase 3: Derived Canvas Data
+
+### 3.1: Write Automated Tests FIRST
+
+- [ ] Create `content/webapp/contexts/ItemViewerContextV2/ItemViewerContextV2.test.tsx`
+- [ ] Create `content/webapp/contexts/ItemViewerContextV2/test-utils.ts` with typed mocks
+- [ ] Write tests for all derived canvas data
+- [ ] Write tests for all boolean flags
+- [ ] Write tests for edge cases (undefined, null, empty)
+- [ ] Create `IIIFViewer.refactored.test.tsx` integration tests
+- [ ] Create `ViewerTopBar.refactored.test.tsx` component tests
+- [ ] Run tests - all pass with current (minimal) implementation
+
+### 3.2 Implementation
+
+- [ ] Add derived values to `IIIFViewer.refactored.tsx` provider
+  - [ ] `currentCanvasIndex`
+  - [ ] `currentCanvas`
+  - [ ] `mainImageService`
+  - [ ] `hasMultipleCanvases`
+  - [ ] `isFirstCanvas`, `isLastCanvas`
+  - [ ] `canNavigateNext`, `canNavigatePrevious`
+  - [ ] `isCurrentCanvasRestricted`
+  - [ ] `hasIiifImageService`
+- [ ] Update `ItemViewerContextV2` type definition
+- [ ] Update `ViewerTopBar.refactored.tsx` to use context values
+- [ ] Update `ZoomedImage.refactored.tsx` to use context values
+- [ ] Update `MainViewer.refactored.tsx` to use context values
+- [ ] Update styled components to use `hasMultipleCanvases`
+
+### 3.3 Verification
+
+- [ ] Run automated tests - all pass
+- [ ] `yarn tsc` - no TypeScript errors
+- [ ] Toggle flag OFF/ON - behaviour identical
+- [ ] (Optional) Manual testing checklist from [14-testing-strategy.md](./14-testing-strategy.md)
+
+**Time checkpoint:** Should take ~6-7 hours total (3h tests + 3-4h implementation)
+
+---
+
+## Phase 4: Download Logic Hook
+
+### 4.1 Write Tests FIRST
+
+- [ ] Create `content/webapp/hooks/useDownloadOptions.test.ts`
+- [ ] Test empty case (no canvas/manifest)
+- [ ] Test IIIF image downloads
+- [ ] Test canvas image downloads from services
+- [ ] Test canvas rendering downloads (PDFs)
+- [ ] Test manifest downloads
+- [ ] Test video/audio downloads
+- [ ] Test `ChoiceBody` handling
+- [ ] Test memoization
+- [ ] All tests pass
+
+### 4.2 Implementation
+
+- [ ] Create `content/webapp/hooks/useDownloadOptions.ts`
+- [ ] Extract download logic from `ViewerTopBar`
+- [ ] Update `ViewerTopBar.refactored.tsx` to use hook
+- [ ] Remove ~65 lines from `ViewerTopBar`
+
+### 4.3 Verification
+
+- [ ] Run automated tests - all pass
+- [ ] Download dropdown appears
+- [ ] All download options present
+- [ ] Download links work
+- [ ] Options update when navigating canvases
+
+**Time checkpoint:** Should take ~4 hours (2h tests + 2h implementation)
+
+---
+
+## Phase 5: Restriction Status
+
+- [ ] Add `isCurrentCanvasRestricted` to context type
+- [ ] Calculate in IIIFViewer.refactored.tsx
+- [ ] Update ViewerTopBar.refactored.tsx to use context value
+- [ ] Remove local calculation from ViewerTopBar
+- [ ] Test restricted badge appears correctly
+- [ ] Test download options respect restriction
+
+**Time checkpoint:** Should take ~1 hour
+
+---
+
+## Phase 6: Duplicate Index Calls
+
+- [ ] Find all `queryParamToArrayIndex(query.canvas)` calls
+- [ ] Update Thumbnails.tsx to use `currentCanvasIndex` from context
+- [ ] Update NoScriptImage.tsx to use `currentCanvasIndex`
+- [ ] Update MultipleManifestList.tsx to use `currentCanvasIndex`
+- [ ] Update any other files found
+- [ ] Test thumbnails highlight correctly
+- [ ] Test all navigation works
+
+**Time checkpoint:** Should take ~30 minutes
+
+---
+
+## Phase 7: Cleanup (After Defaulting to ON)
+
+**Only do this after toggle defaults to ON for 1+ week with no issues!**
+
+- [ ] Remove feature flag from `toggles.ts`
+- [ ] Delete all `.legacy.tsx` files- [ ] Rename `.refactored.tsx` to `.tsx`
+- [ ] Delete wrapper `index.tsx`
+- [ ] Delete old `ItemViewerContext` directory
+- [ ] Rename `ItemViewerContextV2` to `ItemViewerContext`
+- [ ] Update all imports from V2 to standard
+- [ ] Rename test files (remove .refactored)
+- [ ] Update test imports
+- [ ] Run all tests - still pass
+- [ ] `yarn tsc` - no errors
+- [ ] Application runs correctly
+
+**Time checkpoint:** Should take ~1-2 hours
+
+---
+
+## Final Verification
+
+- [ ] All automated tests pass
+- [ ] No TypeScript errors
+- [ ] No console warnings
+- [ ] Feature flag works (or removed if cleanup done)
+- [ ] Manual testing on all browsers
+- [ ] Performance metrics unchanged
+- [ ] Code is cleaner and more maintainable
+- [ ] Documentation updated
+
+---
+
+## Rollout Checklist
+
+- [ ] **Internal testing** - Enable for team members, verify functionality
+- [ ] **Make toggle public** - Available in toggles dashboard for anyone to enable
+- [ ] **Monitor** - Watch Sentry, user reports, performance metrics
+- [ ] **Wait 1-2 weeks** - Let users opt in, gather feedback
+- [ ] **Default to ON** - Change defaultValue to true (users can still opt out)
+- [ ] **Monitor more** - Watch for issues with new default
+- [ ] **Wait 1+ week** - Ensure stability with new default
+- [ ] **Cleanup** - Remove feature flag entirely (Phase 7)
+
+**If issues at any stage:** Disable toggle or revert default, investigate, fix, try again.
+
+---
+
+## Total Time Estimate
+
+- Phase 0: 1-1.5 hours
+- Phase 1: 1 hour
+- Phase 2: 3-4 hours
+- Phase 3: 6-7 hours
+- Phase 4: 4 hours
+- Phase 5: 1 hour
+- Phase 6: 30 minutes
+- Phase 7: 1-2 hours
+
+**Total: 17.5-21 hours**
+
+---
+
+**Next:** [Testing Strategy](./14-testing-strategy.md)

--- a/rfcs/086-item-viewer-refactor/13-phase-7-cleanup.md
+++ b/rfcs/086-item-viewer-refactor/13-phase-7-cleanup.md
@@ -1,0 +1,141 @@
+# Phase 7: Cleanup
+
+[← Back to Index](./README.md)
+
+**Effort:** 1-2 hours  
+**Risk:** Low  
+**Priority:** Required (after toggle has been defaulted to ON)  
+**Previous:** [Phase 6: Duplicate Index Calls](./12-phase-6-duplicate-calls.md)
+
+## Goal
+
+Clean up feature flag infrastructure after successful adoption. Remove legacy code, rename refactored files, and finalize the implementation.
+
+## When to Do This
+
+**Only after:**
+- Toggle defaulted to ON for 1+ week and PM approved
+- No issues reported
+- All metrics stable
+- Team confidence is high
+
+## Steps
+
+### 5.1 Remove Feature Flag
+
+**File:** `toggles/webapp/app/toggles.ts`
+
+```typescript
+// DELETE:
+iiifViewerRefactored: {
+  id: 'iiifViewerRefactored',
+  title: 'IIIF Viewer - Refactored Context',
+  defaultValue: false,
+  description: 'Use refactored ItemViewerContext with centralised derived values',
+},
+```
+
+### 5.2 Delete Legacy Files
+
+```bash
+cd content/webapp/views/pages/works/work/IIIFViewer
+
+# Delete all .legacy.tsx files
+rm IIIFViewer.legacy.tsx
+rm ViewerTopBar.legacy.tsx
+rm ZoomedImage.legacy.tsx
+rm MainViewer.legacy.tsx
+# ... any other .legacy.tsx files
+```
+
+Also remove types that are not in use anymore.
+
+### 5.3 Rename Refactored Files to Standard Names
+
+```bash
+# Rename .refactored.tsx to .tsx
+mv IIIFViewer.refactored.tsx IIIFViewer.tsx
+mv ViewerTopBar.refactored.tsx ViewerTopBar.tsx
+mv ZoomedImage.refactored.tsx ZoomedImage.tsx
+mv MainViewer.refactored.tsx MainViewer.tsx
+```
+
+### 5.4 Delete Wrapper Component
+
+```bash
+# No longer needed - IIIFViewer.tsx is now the main component
+rm index.tsx  # The wrapper that switched between legacy/refactored
+```
+
+### 5.5 Rename Context
+
+```bash
+# Delete old context
+rm -rf content/webapp/contexts/ItemViewerContext
+
+# Rename new context to standard name
+mv content/webapp/contexts/ItemViewerContextV2 \
+   content/webapp/contexts/ItemViewerContext
+```
+
+### 5.6 Update All Imports
+
+Replace all occurrences of `ItemViewerContextV2` with `ItemViewerContext`:
+
+```bash
+# Find all imports
+grep -r "ItemViewerContextV2" content/webapp
+
+# Update each file:
+# OLD: import ItemViewerContextV2 from '@weco/common/contexts/ItemViewerContextV2';
+# NEW: import ItemViewerContext from '@weco/common/contexts/ItemViewerContext';
+```
+
+### 5.7 Remove Unused Props
+
+Identify components that can drop props now that context provides the data:
+
+```typescript
+// Example: ViewerTopBar might have received props that context now provides
+// Remove those props from the interface and component
+```
+
+### 5.8 Update Tests
+
+Rename test files and update imports:
+
+```bash
+mv ItemViewerContextV2.test.tsx ItemViewerContext.test.tsx
+mv IIIFViewer.refactored.test.tsx IIIFViewer.test.tsx
+# Update imports in test files from V2 to standard
+```
+
+### 5.9 Type Cleanup
+
+Ensure all TypeScript types reflect the final context shape. Remove any temporary types used during migration.
+
+### 5.10 Documentation
+
+- [ ] Update inline comments if needed
+- [ ] Remove any "TODO: remove after refactor" comments
+- [ ] Update component documentation if it references old structure
+
+## Success Criteria
+
+- [ ] No more .legacy.tsx files
+- [ ] No more .refactored.tsx files
+- [ ] No ItemViewerContextV2 references
+- [ ] Feature flag removed from toggles
+- [ ] All tests still pass
+- [ ] TypeScript compiles with no errors
+- [ ] Application runs correctly
+- [ ] Code is clean and maintainable
+
+## Time: 1-2 hours
+
+---
+
+The IIIF Viewer context refactoring is complete!
+
+**See also:**
+- [14-risks-and-success.md](./14-risks-and-success.md) - Final success metrics

--- a/rfcs/086-item-viewer-refactor/14-testing-strategy.md
+++ b/rfcs/086-item-viewer-refactor/14-testing-strategy.md
@@ -1,0 +1,399 @@
+# Testing Strategy
+
+[← Back to Index](./README.md)
+
+**Priority:** Automated tests FIRST, manual testing as supplementary safety net.
+
+## Philosophy: Automated Tests Are Primary
+
+**Before writing ANY refactoring code:**
+1. Write comprehensive automated tests for current behaviour
+2. Verify tests pass (establish baseline)
+3. Make refactoring changes
+4. Tests still pass (green to green refactoring)
+5. (Optional) Run manual testing checklist for extra confidence
+
+**Why automated tests first?**
+- Immediate feedback on every change
+- No manual clicking through scenarios
+- Runs in CI/CD on every commit
+- Documents expected behaviour
+- Prevents regressions permanently
+
+## Required Automated Test Coverage
+
+### Before Starting Any Phase
+
+You MUST have automated tests covering:
+
+#### Context Unit Tests
+**File:** `content/webapp/contexts/ItemViewerContextV2/ItemViewerContextV2.test.tsx`
+
+Test ALL derived values:
+- [ ] `currentCanvasIndex` - calculated from `query.canvas` parameter
+- [ ] `currentCanvas` - extracted from `transformedManifest.canvases`
+- [ ] `mainImageService` - extracted from canvas with fallback handling
+- [ ] `hasMultipleCanvases` - true when >1 canvas
+- [ ] `isCurrentCanvasRestricted` - uses `hasRestrictedItem()` helper (from `restricted-images` merge)
+- [ ] `isFirstCanvas` - true when `currentCanvasIndex === 0`
+- [ ] `isLastCanvas` - true when at last canvas
+- [ ] `canNavigateNext` - `!isLastCanvas && hasMultipleCanvases`
+- [ ] `canNavigatePrevious` - `!isFirstCanvas && hasMultipleCanvases`
+- [ ] `hasIiifImageService` - checks for `imageServiceId`
+- [ ] `isImageZoomable` - checks if zoom is supported
+- [ ] `isWorkBornDigital` - checks `work.production` type
+- [ ] `currentProbeServiceId` - extracted from canvas (optional, if added to context)
+
+Test all edge cases:
+- [ ] Undefined `transformedManifest`
+- [ ] Empty canvases array
+- [ ] Canvas without `imageServiceId`
+- [ ] Canvas without `probeServiceId` (non-restricted)
+- [ ] Canvas with `probeServiceId` (restricted)
+- [ ] Invalid canvas index (too high)
+- [ ] Null/undefined values
+
+**New (from `restricted-images` merge):**
+- [ ] `isCurrentCanvasRestricted` returns true for restricted canvas
+- [ ] `isCurrentCanvasRestricted` returns false for non-restricted canvas
+- [ ] `currentProbeServiceId` extracted correctly when present
+- [ ] `currentProbeServiceId` is undefined when absent
+
+#### Component Integration Tests
+**Files:** Component `.refactored.test.tsx` files
+
+Test that components actually consume context values:
+- [ ] **`IIIFViewer.refactored.test.tsx`**
+  - [ ] Provides `currentCanvas` to children
+  - [  ] Provides navigation booleans to children
+  - [ ] Provides boolean flags for conditional rendering
+  
+- [ ] **`ViewerTopBar.refactored.test.tsx`**
+  - [ ] Uses `currentCanvas` from context (not calculating)
+  - [ ] Uses navigation booleans for button states
+  - [ ] Uses `isCurrentCanvasRestricted` for restriction badge
+  - [ ] Uses `hasDownloadOptions` for download button
+  
+- [ ] **`ZoomedImage.refactored.test.tsx`**
+  - [ ] Uses `currentCanvas` from context
+  - [ ] Uses `mainImageService` from context
+  - [ ] Handles empty `mainImageService` correctly
+
+#### Download Options Hook Tests (Phase 2)
+**File:** `content/webapp/hooks/useDownloadOptions.test.ts`
+
+Test download option calculations:
+- [ ] Returns empty array when no canvas or manifest
+- [ ] Includes IIIF image download options
+- [ ] Includes canvas image downloads from services
+- [ ] Includes canvas rendering downloads (PDFs)
+- [ ] Includes manifest-level downloads
+- [ ] Includes video/audio downloads
+- [ ] Handles ChoiceBody items correctly
+- [ ] **Deduplicates downloads with same id** (from `restricted-images` merge)
+- [ ] Memoises results correctly
+- [ ] Updates when dependencies change
+
+Test edge cases:
+- [ ] Multiple downloads with different URLs (all included)
+- [ ] Multiple downloads with same URL (only one included after dedup)
+- [ ] ChoiceBody in `rendering` array
+- [ ] ChoiceBody in `supplementing` array
+- [ ] Empty download arrays
+- [ ] Restricted downloads for staff vs non-staff users
+
+#### Mock Utilities
+**File:** `content/webapp/contexts/ItemViewerContextV2/test-utils.ts`
+
+- [ ] `mockDefaultContext` with proper TypeScript types
+- [ ] Helper functions for creating test manifests
+- [ ] Helper functions for creating test canvases
+- [ ] All mocks properly typed (no `any`)
+
+### Test Examples
+
+See [refactoring-iiif-viewer-context-testing.md](./refactoring-iiif-viewer-context-testing.md) for complete TypeScript test examples.
+
+Quick example:
+
+```typescript
+describe('ItemViewerContextV2 - Derived Canvas Data', () => {
+  it('should calculate currentCanvasIndex from canvas query param', () => {
+    const contextValue: ItemViewerContextV2Props = {
+      ...mockDefaultContext,
+      query: { canvas: 3, manifest: 1, page: 1, shouldScrollToCanvas: true, query: '' },
+      currentCanvasIndex: 2, // canvas=3 to index 2 (1-indexed to 0-indexed)
+    };
+
+    render(
+      <ItemViewerContextV2.Provider value={contextValue}>
+        <ContextValueDisplay />
+      </ItemViewerContextV2.Provider>
+    );
+
+    expect(screen.getByTestId('currentCanvasIndex')).toHaveTextContent('2');
+  });
+});
+```
+
+## Manual Testing Checklist
+
+**Use this AFTER automated tests pass as an extra safety net.**
+
+### For Each Phase: Core Functionality
+
+- [ ] **Navigate between canvases**
+  - [ ] Thumbnails navigation works
+  - [ ] Next/Previous buttons work
+  - [ ] URL updates with canvas number
+  - [ ] Page title updates
+  
+- [ ] **UI controls**
+  - [ ] Sidebar toggle (desktop)
+  - [ ] Sidebar toggle (mobile)
+  - [ ] Grid view toggle (multi-canvas works only)
+  - [ ] Zoom in/out controls
+  - [ ] Fullscreen mode
+  
+- [ ] **Visual appearance**
+  - [ ] Layout looks correct
+  - [ ] Images load correctly
+  - [ ] No console errors
+  - [ ] No React warnings
+
+### Different Work Types
+
+Test with these specific work types:
+
+- [ ] **Multi-canvas image work** (`/works/[id]/images`)
+  - [ ] Canvas count shows correctly
+  - [ ] Grid view available
+  - [ ] Navigation between canvases works
+  - [ ] Download options appear
+  
+- [ ] **Single canvas work**
+  - [ ] No grid view toggle (should be hidden)
+  - [ ] Navigation buttons hidden/disabled
+  - [ ] Layout optimised for single canvas
+  
+- [ ] **Archive items** (`/works/[id]/items`)
+  - [ ] Archive tree navigation works
+  - [ ] Correct canvas loads from tree selection
+  - [ ] Breadcrumb navigation works
+  
+- [ ] **Restricted access works**
+  - [ ] Restriction badge appears
+  - [ ] Auth flow works correctly
+  - [ ] Restricted content shows after auth
+  - [ ] Download disabled for restricted canvas
+  
+- [ ] **Works with video/audio**
+  - [ ] Video player appears
+  - [ ] Audio player appears
+  - [ ] Download options include video/audio
+  
+- [ ] **Works with downloadable PDFs**
+  - [ ] PDF download option appears
+  - [ ] PDF downloads correctly
+
+### Specific Test Works
+
+Test each work type with all three authentication states. For each scenario, verify behavior is **identical** with toggle ON vs toggle OFF:
+- **Logged out** - no authentication
+- **Logged in (regular user)** - standard library member
+- **Logged in (restricted access)** - user with restricted content access
+
+#### Restricted Whole Item
+- Work page: https://www-dev.wellcomecollection.org/works/rp9jnamu
+- Items page: https://www-dev.wellcomecollection.org/works/rp9jnamu/items
+
+Test with: Logged out | Logged in (regular) | Logged in (restricted)
+
+#### Restricted/Clickthrough Mix
+- Work page: https://www-dev.wellcomecollection.org/works/pnud3fzb
+- Items page: https://www-dev.wellcomecollection.org/works/pnud3fzb/items
+
+Test with: Logged out | Logged in (regular) | Logged in (restricted)
+
+#### Restricted Audio
+- Work page: https://www-dev.wellcomecollection.org/works/esd6gs3s
+- Items page: https://www-dev.wellcomecollection.org/works/esd6gs3s/items
+
+Test with: Logged out | Logged in (regular) | Logged in (restricted)
+
+#### Restricted Video
+- Work page: https://www-dev.wellcomecollection.org/works/zsgh5y3z
+- Items page: https://www-dev.wellcomecollection.org/works/zsgh5y3z/items
+
+Test with: Logged out | Logged in (regular) | Logged in (restricted)
+
+#### Restricted Born Digital
+- Work page: https://www-dev.wellcomecollection.org/works/my6bzerr
+- Items page: https://www-dev.wellcomecollection.org/works/my6bzerr/items
+
+Test with: Logged out | Logged in (regular) | Logged in (restricted)
+
+#### Regular Video (unrestricted)
+- Work page: https://www-dev.wellcomecollection.org/works/a9w3qy3j
+- Items page: https://www-dev.wellcomecollection.org/works/a9w3qy3j/items
+
+Test with: Logged out | Logged in (regular) | Logged in (restricted)
+
+### Edge Cases
+
+- [ ] **Works with no manifest**
+  - [ ] Error message displays gracefully
+  - [ ] No JavaScript errors
+  
+- [ ] **Works with JavaScript disabled (progressive enhancement)**
+  - [ ] NoScriptImage component renders on server
+  - [ ] Image is visible without JavaScript enabled
+  - [ ] OCR text is accessible (check view source)
+  - [ ] Page doesn't appear broken
+  
+- [ ] **Works with empty canvases**
+  - [ ] Handles gracefully
+  - [ ] No infinite loops or crashes
+  
+- [ ] **Missing image services**
+  - [ ] Falls back to alternative rendering
+  - [ ] No broken images
+  
+- [ ] **Invalid canvas numbers**
+  - [ ] `/works/[id]/items?canvas=999` redirects or shows error
+  - [ ] No crashes
+  
+- [ ] **Canvas without imageServiceId**
+  - [ ] Still renders (uses alternative)
+  - [ ] Zoom controls hidden
+  - [ ] No console errors
+
+### Normalisation-Specific Tests
+
+These are critical when normalising variant implementations:
+
+#### Test `currentCanvas` Normalisation
+
+Different components previously calculated `currentCanvas` differently. Verify they all work:
+
+| Component | Previous Implementation | What to Test |
+|-----------|------------------------|--------------|
+| `ViewerTopBar` | `canvases?.[index]` | Download options appear, canvas title shows |
+| `ZoomedImage` | `transformedManifest?.canvases[index]` | Zoom shows correct canvas image |
+| `MainViewer` | May calculate independently | Canvas scrolling works, canvas displays correctly |
+| `Thumbnails` | Used `queryParamToArrayIndex` directly | Correct thumbnail highlighted |
+
+**Key question:** Verify the `|| ''` fallback only exists where genuinely needed.
+
+| Component | Previous Implementation | What to Test |
+|-----------|------------------------|--------------|
+| `IIIFViewer` | No `\|\| ''` fallback | `iiifImageTemplate` handles undefined correctly |
+| `ZoomedImage` | Had `\|\| ''` fallback | Verify `convertRequestUriToInfoUri` still works |
+
+**Test both:**
+1. Canvas WITH `imageServiceId` - zoom should work
+2. Canvas WITHOUT `imageServiceId` - should fall back gracefully, no errors
+
+**Critical:** Test on all supported browsers BEFORE releasing.
+
+- [ ] **Chrome/Edge** (latest)
+  - [ ] All core functionality
+  - [ ] Zoom controls
+  - [ ] Fullscreen
+  - [ ] Downloads
+  
+- [ ] **Firefox** (latest)
+  - [ ] All core functionality
+  - [ ] Check for Firefox-specific quirks
+  
+- [ ] **Safari** (latest macOS)
+  - [ ] All core functionality
+  - [ ] Image rendering
+  - [ ] Fullscreen API differences
+  
+- [ ] **Mobile Safari** (iOS)
+  - [ ] Sidebar toggle works
+  - [ ] Touch navigation
+  - [ ] Pinch to zoom
+  - [ ] Fullscreen on mobile
+  
+- [ ] **Mobile Chrome** (Android)
+  - [ ] Sidebar toggle works
+  - [ ] Touch navigation
+  - [ ] Downloads work
+
+### Performance Testing
+
+- [ ] **Large manifests** (100+ canvases)
+  - [ ] Page loads within 3 seconds
+  - [ ] No lag when navigating
+  - [ ] Thumbnails load smoothly
+  
+- [ ] **React DevTools Profiler**
+  - [ ] Check for unnecessary re-renders
+  - [ ] Verify memoization works
+  - [ ] Compare before/after performance
+
+### Comparison Testing (Legacy vs Refactored)
+
+**Most important test:** Side-by-side comparison.
+
+For each work type listed above:
+1. Test with feature flag OFF (legacy)
+2. Note behaviour, take screenshots
+3. Test with feature flag ON ( refactored)
+4. Verify IDENTICAL behaviour and appearance
+5. Document any differences (should be zero)
+
+## Test Work IDs
+
+Use these specific works for comprehensive testing:
+
+```
+// Add actual work IDs here based on production data
+- Multi-canvas work: /works/[ID]/images
+- Single canvas work: /works/[ID]/images
+- Restricted work: /works/[ID]/items
+- Video work: /works/[ID]/items
+- Archive item: /works/[ID]/items
+```
+
+## When Manual Testing Finds Issues
+
+If manual testing reveals a bug that automated tests didn't catch:
+
+1. **Write an automated test for the bug FIRST**
+2. Verify the test fails (reproduces the bug)
+3. Fix the bug
+4. Verify the test passes
+5. Add test to permanent test suite
+
+This prevents the bug from reoccurring and improves test coverage.
+
+## Success Criteria
+
+Before marking a phase complete:
+
+**Required:**
+- [ ] All automated tests pass with flag OFF (legacy)
+- [ ] All automated tests pass with flag ON (refactored)
+- [ ] TypeScript compiles with no errors
+- [ ] No console warnings or errors
+- [ ] Test coverage >80% for new code
+
+**Highly Recommended:**
+- [ ] Manual testing checklist completed
+- [ ] Tested on all browsers
+- [ ] Comparison testing shows identical behaviour
+- [ ] Performance profiling shows no regressions
+
+---
+
+**See also:**
+- [refactoring-iiif-viewer-context-testing.md](./refactoring-iiif-viewer-context-testing.md) - Complete TypeScript test examples
+- [04-test-first-approach.md](./04-test-first-approach.md) - Why we test first
+- [13-migration-checklist.md](./13-migration-checklist.md) - Per-phase checklists
+
+---
+
+**Next:** [Risks & Success Metrics](./15-risks-and-success.md)

--- a/rfcs/086-item-viewer-refactor/15-risks-and-success.md
+++ b/rfcs/086-item-viewer-refactor/15-risks-and-success.md
@@ -1,0 +1,287 @@
+# Risks & Success Metrics
+
+[← Back to Index](./README.md)
+
+## Risk Mitigation
+
+### Performance Concerns
+
+**Risk:** Adding more data to context could cause unnecessary re-renders across all consuming components.
+
+**Likelihood:** Low  
+**Impact:** Medium  
+
+**Mitigation:**
+- Use `useMemo` for all derived calculations in context provider
+- Test render performance with React DevTools Profiler before and after
+- Consider splitting context if it grows too large:
+  - `ItemViewerDataContext` (work, manifest, query, derived data)
+  - `ItemViewerUIContext` (sidebar, zoom, grid states)
+- Monitor bundle size - ensure no significant increase
+- Profile with large manifests (100+ canvases)
+
+**Detection:**
+- React DevTools shows excessive re-renders
+- Lighthouse performance scores decrease
+- User reports of lag or slowness
+
+---
+
+### Breaking Changes
+
+**Risk:** Components might depend on local state in ways not immediately obvious. Subtle behaviour changes could occur.
+
+**Likelihood:** Low (with test-first approach)  
+**Impact:** High  
+
+**Mitigation:**
+- Test-first approach catches regressions immediately
+- Feature flag allows instant rollback (disable toggle)
+- Keep PR size manageable - merge phases separately if needed
+- Side-by-side comparison testing (flag ON vs OFF)
+- Comprehensive manual testing checklist
+- Monitor Sentry for errors while toggle is public
+
+**Detection:**
+- Automated tests fail
+- Manual testing reveals differences
+- Sentry error spike
+- User reports of broken functionality
+
+**Rollback:** Disable toggle or revert default, investigate, fix in development, re-enable.
+
+---
+
+### Normalisation Risk
+
+**Risk:** When normalising variant implementations (e.g., `currentCanvas` calculated differently in `ViewerTopBar` vs `ZoomedImage`), the chosen canonical version might not handle all edge cases that the variants handled.
+
+**Likelihood:** Low (with characterisation tests)  
+**Impact:** Medium  
+
+**Mitigation:**
+- Write characterisation tests BEFORE refactoring
+- Test all edge cases from all variants
+- Document why canonical version was chosen
+- Review each variant's fallback behaviour
+- Side-by-side comparison testing
+
+**Detection:**
+- Tests fail during refactoring
+- Manual testing reveals edge case failures
+- Unexpected undefined/null values
+
+**Rollback:** Fix canonical implementation to handle all edge cases, or disable toggle.
+
+---
+
+### Type Safety Issues
+
+**Risk:** TypeScript type errors during refactoring, especially with complex IIIF types.
+
+**Likelihood:** Medium  
+**Impact:** Low (caught at compile time)  
+
+**Mitigation:**
+- Update types first before implementation
+- Use TypeScript strict mode
+- Fix all type errors before testing
+- Properly type all mocks and test fixtures
+- Use IDE type checking during development
+- Run `yarn tsc` frequently during development
+
+**Detection:**
+- TypeScript compiler errors
+- IDE showing  type errors
+- CI/CD build failures
+
+**Resolution:** Fix type errors before proceeding. Don't use `any` or `@ts-ignore` to bypass.
+
+---
+
+### Normalisation Risks
+
+**Risk:** When normalising variant implementations (e.g., `currentCanvas` calculated differently in ViewerTopBar vs ZoomedImage), the chosen canonical version might not handle all edge cases that the variants handled.
+
+**Likelihood:** Low (with comprehensive tests)  
+**Impact:** Medium  
+
+**Mitigation:**
+- Document all current implementations before refactoring (phase 1.0)
+- Test all edge cases from all variants
+- Check fallback behaviour (`|| ''` might be needed in some cases, not others)
+- Verify with null, undefined, and empty cases
+- Compare behaviour with toggle OFF (legacy) vs ON (refactored)
+
+**Detection:**
+- Automated tests catch edge case failures
+- Manual testing reveals UI differences
+- Images don't load correctly
+- Zoom doesn't work in specific scenarios
+
+**Resolution:** Adjust canonical implementation to handle all edge cases, or add component-specific logic where genuinely needed.
+
+---
+
+### Feature Flag Debt
+
+**Risk:** Feature flag left in codebase permanently, creating permanent branching logic.
+
+**Likelihood:** Medium (without discipline)  
+**Impact:** Medium  
+
+**Mitigation:**
+- Set calendar reminder for cleanup (2 weeks after defaulting to ON)
+- Include cleanup phase in original plan (Phase 5)
+- Document cleanup steps clearly
+- Make cleanup PR part of the original epic/project
+- Don't consider project "done" until cleanup is merged
+
+**Detection:**
+- Feature flag still present months later
+- `.legacy.tsx` and `.refactored.tsx` files still in codebase
+- Wrapper logic still checking feature flag
+
+**Resolution:** Follow Phase 5 cleanup steps. Remove legacy code, rename refactored code, delete flag.
+
+---
+
+## Success Metrics
+
+### Code Quality Metrics
+
+**Target:** Improvement across all metrics
+
+- **Code reduction:** 150-200 lines removed across components
+  - ViewerTopBar: ~65 lines (download logic)
+  - IIIFViewer: ~20 lines (calculation logic)
+  - ZoomedImage: ~10 lines
+  - Other components: ~55-105 lines combined
+  
+- **DRY improvement:** Zero duplication of:
+  - `currentCanvas` calculation (was in 4 files)
+  - `queryParamToArrayIndex` calls (was in 3 files)
+  - Download options logic (was only in `ViewerTopBar`, now reusable)
+  
+- **Cyclomatic complexity:** Reduced by ~15-20 points
+  - `ViewerTopBar` complexity reduced significantly
+  - `IIIFViewer` complexity reduced
+  
+- **Test coverage:** Increased to >80% for IIIF Viewer components
+  - ItemViewerContext: 100% coverage
+  - useDownloadOptions: 100% coverage
+  - Component integration: >80% coverage
+
+### Maintainability Metrics
+
+**Target:** Easier to understand and modify
+
+- **Single source of truth:** All derived values calculated once, in context
+- **Clear naming:** All booleans follow `is/has/can/should` pattern
+- **Separation of concerns:** Business logic in context/hooks, presentation in components
+- **Reusability:** Download logic hook can be used anywhere
+- **Type safety:** All mocks and context values properly typed
+
+### Performance Metrics
+
+**Target:** No regression (same or better performance)
+
+- **Bundle size:** No increase >2KB gzipped
+- **Render time:** No increase (verify with React Profiler)
+- **Lighthouse score:** Maintain 90+ performance score
+- **First Contentful Paint:** Maintain <1.5s
+- **Time to Interactive:** Maintain <3s
+
+**How to measure:**
+- Before refactoring: Profile with React DevTools, record Lighthouse scores
+- After refactoring: Profile again, compare
+- Monitor in production with Real User Monitoring (RUM)
+
+### Developer Experience Metrics
+
+**Target:** Easier to work with
+
+- **Onboarding time:** New developers understand viewer code faster
+- **Bug fix time:** Easier to locate and fix issues
+- **Feature development time:** Easier to add new features
+- **Code review time:** PRs easier to review (less mental gymnastics)
+
+**Qualitative feedback:**
+- Team survey: "Is the refactored code easier to understand?"
+- Code review comments: Fewer questions about "what does this do?"
+- Bug reports: Fewer viewer-related bugs after refactor
+
+---
+
+## Success Criteria
+
+The refactoring is successful if:
+
+1. All automated tests pass when toggle is enabled
+2. Performance metrics unchanged or improved
+3. Error rate in production unchanged
+4. Code is more maintainable (team consensus)
+5. 150+ lines of code removed
+6. Zero duplication of derived calculations
+7. Feature flag successfully removed (cleanup complete)
+8. Team agrees code is easier to understand
+
+The refactoring has failed if:
+
+1. Tests reveal regressions we can't fix
+2. Performance degrades significantly
+3. Error rate spikes in production
+4. Must revert to legacy implementation
+5. Team finds new code harder to understand
+6. User-facing bugs introduced
+
+---
+
+## Next Steps
+
+After successfully completing this refactoring:
+
+1. Monitor production metrics for 1-2 weeks with toggle enabled
+2. Review team feedback on code maintainability
+3. If all success criteria met, proceed to [Phase 5: Cleanup](./12-phase-5-cleanup.md)
+4. Consider [Future Improvements](./16-future-improvements.md) like component splitting
+
+For different viewer modes:
+
+```typescript
+type ViewerMode = 
+  | { type: 'images'; work: ImageWork }
+  | { type: 'archive'; work: ArchiveWork; archiveTree: ArchiveTree }
+  | { type: 'restricted'; work: RestrictedWork; authStatus: AuthStatus };
+```
+
+**Benefit:** Type-safe mode handling
+
+### 3. Extract Search Results Logic
+
+Move search highlighting logic to custom hook:
+
+```typescript
+const searchMatches = useSearchMatches(currentCanvas, searchTerm);
+```
+
+**Benefit:** Reusable, testable search logic
+
+### 4. Performance Optimizations
+
+- Lazy load large canvases
+- Virtual scrolling for 100+ canvas works
+- Web Workers for image processing
+- Service Worker for offline viewing
+
+**Benefit:** Better performance for large works
+
+---
+
+**See also:**
+- [13-testing-strategy.md](./13-testing-strategy.md) - How to verify success
+- [13-migration-checklist.md](./13-migration-checklist.md) - Track your progress
+
+---
+
+**Next:** [Future Improvements](./16-future-improvements.md)

--- a/rfcs/086-item-viewer-refactor/16-future-improvements.md
+++ b/rfcs/086-item-viewer-refactor/16-future-improvements.md
@@ -1,0 +1,297 @@
+# Future Improvements
+
+[← Back to Index](./README.md)
+
+After the main refactoring succeeds, consider these architectural improvements.
+
+## 1. Further Context Splitting
+
+### Problem: Components with Two Faces
+
+Several components have completely different rendering logic based on boolean conditionals, violating the Single Responsibility Principle.
+
+**Example: MainViewer**
+
+`MainViewer.tsx` has two fundamentally different implementations:
+
+```typescript
+if (hasOnlyRenderableImages) {
+  // Mode A: Virtualized image scrolling with FixedSizeList
+  return <FixedSizeList>{ItemRenderer}</FixedSizeList>;
+}
+
+// Mode B: Direct item rendering with IIIFItem components
+return <>{displayItems.map(item => <IIIFItem />)}</>;
+```
+
+These are two different components with:
+- Different data requirements
+- Different performance characteristics  
+- Different rendering strategies
+- Different testing needs
+
+### Recommendation: Split into Separate Components
+
+**Before:**
+```
+MainViewer
+  ├── if (hasOnlyRenderableImages) { FixedSizeList logic }
+  └── else { IIIFItem rendering }
+```
+
+**After:**
+```
+MainViewer (router component)
+  ├── VirtualizedImageViewer (for image-only works)
+  └── PaginatedItemViewer (for mixed content/archives)
+```
+
+**Benefits:**
+- **Clarity:** Each component has one clear purpose
+- **Testability:** Test each mode independently
+- **Performance:** Separate bundle chunks, load only what's needed
+- **Maintainability:** Changes to one mode don't affect the other
+- **Type safety:** Each component has its own specific props
+
+### Implementation
+
+**File:** `content/webapp/views/pages/works/work/IIIFViewer/MainViewer.tsx`
+
+```typescript
+import { FunctionComponent } from 'react';
+import { useItemViewerContext } from '@weco/content/contexts/ItemViewerContext';
+
+// New components (in separate files)
+import VirtualizedImageViewer from './VirtualizedImageViewer';
+import PaginatedItemViewer from './PaginatedItemViewer';
+
+const MainViewer: FunctionComponent = () => {
+  const { hasOnlyRenderableImages } = useItemViewerContext();
+  
+  // Router component: decide which implementation to use
+  if (hasOnlyRenderableImages) {
+    return <VirtualizedImageViewer />;
+  }
+  
+  return <PaginatedItemViewer />;
+};
+
+export default MainViewer;
+```
+
+**New file:** `VirtualizedImageViewer.tsx`
+```typescript
+// Only handles image-only works with virtualized scrolling
+import { FunctionComponent } from 'react';
+import { FixedSizeList } from 'react-window';
+
+const VirtualizedImageViewer: FunctionComponent = () => {
+  const {
+    mainAreaWidth,
+    mainAreaHeight,
+    canvases,
+    rotatedImages,
+    // ... only props needed for this mode
+  } = useItemViewerContext();
+  
+  return (
+    <FixedSizeList
+      width={mainAreaWidth}
+      height={mainAreaHeight}
+      itemCount={canvases?.length || 0}
+      // ... virtualization logic
+    >
+      {ItemRenderer}
+    </FixedSizeList>
+  );
+};
+```
+
+**New file:** `PaginatedItemViewer.tsx`
+```typescript
+// Only handles mixed content and archives
+import { FunctionComponent } from 'react';
+
+const PaginatedItemViewer: FunctionComponent = () => {
+  const {
+    currentCanvas,
+    canvases,
+    canvas,
+    // ... only props needed for this mode
+  } = useItemViewerContext();
+  
+  const displayItems = currentCanvas ? getDisplayItems(currentCanvas) : [];
+  
+  return (
+    <>
+      {displayItems.map((item, i) => (
+        <IIIFItem
+          item={item}
+          canvas={currentCanvas}
+          // ... item rendering
+        />
+      ))}
+    </>
+  );
+};
+```
+
+### Other Candidates for Splitting
+
+Look for these patterns:
+- Large if/else blocks returning different JSX
+- Components with multiple "modes" or "types"
+- Boolean props that drastically change behaviour (`hasOnlyRenderableImages`, `isArchive`, `isRestricted`)
+- Different event handlers based on conditionals
+
+**Potential candidates in ItemViewer:**
+- `IIIFViewer.tsx` - different rendering for image-only vs mixed content
+- Any component checking `hasOnlyRenderableImages` extensively
+
+### When NOT to Split
+
+Don't split if:
+- It's just conditional rendering of small UI elements (buttons, labels)
+- The modes share significant logic
+- The conditional is for progressive enhancement (browser support)
+- Splitting would create more complexity than it solves
+
+### Testing Strategy
+
+After splitting:
+1. Test each component independently with focused test suites
+2. Test the router component's decision logic
+3. Verify no regressions in E2E tests
+4. Check bundle size hasn't increased significantly
+
+---
+
+## 2. Further Context Splitting
+
+If context grows too large or causes performance issues:
+
+```
+ItemViewerContext (current)
+  ↓
+Split into:
+  ├── ItemViewerDataContext (work, manifest, derived data)
+  └── ItemViewerUIContext (sidebar, zoom, grid, fullscreen)
+```
+
+**Benefit:** More granular re-rendering control
+
+**When to do this:** 
+- React Profiler shows excessive re-renders
+- UI state changes cause data components to re-render unnecessarily
+- Context has >20 values
+
+---
+
+## 3. TypeScript Discriminated Unions for Viewer Modes
+
+Make viewer modes type-safe with discriminated unions:
+
+```typescript
+type ViewerMode = 
+  | { 
+      type: 'image-gallery';
+      hasOnlyRenderableImages: true;
+      canvases: TransformedCanvas[];
+    }
+  | { 
+      type: 'archive';
+      hasOnlyRenderableImages: false;
+      archiveTree: UiTree;
+      currentCanvas: TransformedCanvas;
+    }
+  | { 
+      type: 'restricted';
+      hasOnlyRenderableImages: false;
+      authStatus: AuthStatus;
+    };
+
+type ItemViewerContextProps = {
+  // ... common props
+  mode: ViewerMode;
+};
+```
+
+**Benefit:** 
+- TypeScript enforces that archive-specific props only exist in archive mode
+- Impossible to use `archiveTree` in image-gallery mode (compile error)
+- Self-documenting code
+
+---
+
+## 4. Extract Complex State Machines
+
+Use state machine libraries for complex UI state:
+
+```typescript
+import { useMachine } from '@xstate/react';
+
+const viewerMachine = createMachine({
+  initial: 'loading',
+  states: {
+    loading: {
+      on: { LOADED: 'viewing' }
+    },
+    viewing: {
+      on: { 
+        ZOOM: 'zoomed',
+        FULLSCREEN: 'fullscreen',
+        ERROR: 'error'
+      }
+    },
+    zoomed: {
+      on: { CLOSE: 'viewing' }
+    },
+    // ...
+  }
+});
+```
+
+**When:** Complex state transitions with many edge cases
+
+---
+
+## 5. Performance Monitoring
+
+Add performance instrumentation:
+
+```typescript
+import { useReportEffect } from '@weco/common/hooks/useReportEffect';
+
+function ItemViewerContextProvider({ children }) {
+  useReportEffect('ItemViewerContext render');
+  
+  // Mark expensive calculations
+  const derivedData = useMemo(() => {
+    performance.mark('derive-canvas-data-start');
+    const result = deriveCanvasData(manifest, query);
+    performance.mark('derive-canvas-data-end');
+    performance.measure(
+      'derive-canvas-data',
+      'derive-canvas-data-start',
+      'derive-canvas-data-end'
+    );
+    return result;
+  }, [manifest, query]);
+  
+  // ...
+}
+```
+
+Track in production to identify bottlenecks.
+
+---
+
+## Priority Order
+
+1. **Component splitting** - High impact, relatively easy, improves clarity immediately
+2. **Context splitting** - Only if performance issues detected
+3. **Discriminated unions** - Nice to have, consider if making large type changes
+4. **State machines** - Only if state management becomes very complex
+5. **Performance monitoring** - Implement if performance concerns arise
+
+Start with component splitting if the main refactoring goes well.

--- a/rfcs/086-item-viewer-refactor/README.md
+++ b/rfcs/086-item-viewer-refactor/README.md
@@ -1,0 +1,81 @@
+# IIIF Viewer Context Refactoring
+
+**Status:** Not started  
+**Created:** 1 April 2026  
+**Estimated effort:** 14-17 hours  
+**Priority:** Medium  
+
+## Quick Start
+
+This folder contains a comprehensive plan to refactor the IIIF Viewer context to eliminate code duplication and centralise derived state calculations.
+
+**Key principle:** Write automated tests BEFORE refactoring (test-first approach), then use manual testing for extra confidence.
+
+## Table of Contents
+
+### Understanding the Problem
+- [01 - Overview](./01-overview.md) - Problem statement, current architecture, and duplication examples
+- [02 - Normalisation Strategy](./02-normalisation-strategy.md) - Why and how we normalise variant implementations
+- [03 - Naming Conventions](./03-naming-conventions.md) - Crystal-clear boolean naming patterns
+
+### Approach
+- [04 - Test-First Methodology](./04-test-first-approach.md) - **Write tests BEFORE refactoring** (automated tests are priority)
+- [05 - Feature Flag Strategy](./05-feature-flag-strategy.md) - Safe rollout with feature flags
+
+### Implementation Phases
+- [06 - Phase 0: Type Audit](./06-phase-0-type-audit.md) (1-1.5 hours) - Do this first: Fix implicit `any` types & validate against official specs
+- [07 - Phase 1: Feature Flag Setup](./07-phase-1-feature-flag.md) (1 hour)
+- [08 - Phase 2: Split MainViewer Components](./08-phase-2-split-components.md) (3-4 hours) - Split before context refactoring
+- [09 - Phase 3: Canvas Data](./09-phase-3-canvas-data.md) (6-7 hours) - **Includes comprehensive automated tests**
+- [10 - Phase 4: Download Logic](./10-phase-4-download-logic.md) (2 hours)
+- [11 - Phase 5: Restriction Status](./11-phase-5-restriction-status.md) (1 hour)
+- [12 - Phase 6: Duplicate Index Calls](./12-phase-6-duplicate-calls.md) (30 mins)
+- [13 - Phase 7: Cleanup](./13-phase-7-cleanup.md) (1-2 hours)
+
+### Reference
+- [13 - Migration Checklist](./13-migration-checklist.md) - Step-by-step checklist for each phase
+- [14 - Testing Strategy](./14-testing-strategy.md) - **Automated tests (priority) + manual testing checklist**
+- [15 - Risks & Success Metrics](./15-risks-and-success.md) - Risk mitigation and success criteria
+- [16 - Future Improvements](./16-future-improvements.md) - Post-refactor architectural improvements
+- [Testing Guide](./refactoring-iiif-viewer-context-testing.md) - Detailed test examples with TypeScript types
+
+## Quick Navigation
+
+### I want to understand the refactoring
+Start with [01-overview.md](./01-overview.md)
+
+### I want to implement Phase 3
+Read [09-phase-3-canvas-data.md](./09-phase-3-canvas-data.md) and [Testing Guide](./refactoring-iiif-viewer-context-testing.md)
+
+### I want to see test examples
+Go to [Testing Guide](./refactoring-iiif-viewer-context-testing.md) for complete TypeScript test examples
+
+### I want the testing checklist
+See [14-testing-strategy.md](./14-testing-strategy.md) for automated test requirements and manual testing checklist
+
+## Key Principles
+
+1. **Fix types first** - Audit and fix all types before refactoring (Phase 0)
+2. **Automated tests BEFORE refactoring** - Build comprehensive test coverage first
+3. **Feature flag everything** - Safe rollout with instant rollback capability
+4. **Crystal-clear naming** - Use `is...`, `has...`, `can...`, `should...` patterns for booleans
+5. **Test-first workflow** - Green to Green refactoring (tests pass before and after)
+6. **Manual tests as backup** - Comprehensive checklist for extra confidence
+7. **Context for shared state only** - Only add to context if used by 2+ components or likely to be needed soon
+8. **Hooks for complex logic** - Extract to custom hooks for testability, even if only used once8. **Split components with drastically different modes** - See [Future Improvements](./16-future-improvements.md) for details
+## Progress Tracking
+
+- [ ] Phase 0: Type Audit
+- [ ] Phase 1: Feature Flag Setup
+- [ ] Phase 2: Split MainViewer Components
+- [ ] Phase 3: Canvas Data (with automated tests)
+- [ ] Phase 4: Download Logic
+- [ ] Phase 5: Restriction Status
+- [ ] Phase 6: Duplicate Calls
+- [ ] Phase 7: Cleanup
+
+---
+
+**Related Documentation:**
+- [AGENTS.md](../../AGENTS.md) - Development guidelines (British English, coding standards)
+- [.github/copilot-instructions.md](../../.github/copilot-instructions.md) - PR review guidelines

--- a/rfcs/086-item-viewer-refactor/refactoring-iiif-viewer-context-testing.md
+++ b/rfcs/086-item-viewer-refactor/refactoring-iiif-viewer-context-testing.md
@@ -1,0 +1,554 @@
+# IIIF Viewer Context Refactoring - Testing Guide
+
+**Related:** See [refactoring-iiif-viewer-context.md](./refactoring-iiif-viewer-context.md) for the main refactoring plan.
+
+This document contains detailed test examples for the IIIF Viewer context refactoring. All tests should use proper TypeScript types.
+
+## Phase 1 Testing
+
+### 1.1 Context Provider Unit Tests
+
+**File:** `content/webapp/contexts/ItemViewerContextV2/ItemViewerContextV2.test.tsx`
+
+```typescript
+import { render, screen } from '@testing-library/react';
+import type { FC } from 'react';
+
+import ItemViewerContextV2, { ItemViewerContextV2Props } from './index';
+import { mockDefaultContext } from './test-utils';
+
+// Test component that displays context values
+const ContextValueDisplay: FC = () => {
+  const {
+    currentCanvas,
+    currentCanvasIndex,
+    mainImageService,
+    hasMultipleCanvases,
+    isCurrentCanvasRestricted,
+    isFirstCanvas,
+    isLastCanvas,
+    canNavigateNext,
+    canNavigatePrevious,
+    hasIiifImageService,
+    isImageZoomable,
+    isWorkBornDigital,
+  } = ItemViewerContextV2._currentValue;
+
+  return (
+    <div>
+      <div data-testid="currentCanvasIndex">{currentCanvasIndex}</div>
+      <div data-testid="currentCanvasId">{currentCanvas?.id || 'none'}</div>
+      <div data-testid="mainImageServiceId">{mainImageService['@id'] || 'none'}</div>
+      <div data-testid="hasMultipleCanvases">{String(hasMultipleCanvases)}</div>
+      <div data-testid="isCurrentCanvasRestricted">{String(isCurrentCanvasRestricted)}</div>
+      <div data-testid="isFirstCanvas">{String(isFirstCanvas)}</div>
+      <div data-testid="isLastCanvas">{String(isLastCanvas)}</div>
+      <div data-testid="canNavigateNext">{String(canNavigateNext)}</div>
+      <div data-testid="canNavigatePrevious">{String(canNavigatePrevious)}</div>
+      <div data-testid="hasIiifImageService">{String(hasIiifImageService)}</div>
+      <div data-testid="isImageZoomable">{String(isImageZoomable)}</div>
+      <div data-testid="isWorkBornDigital">{String(isWorkBornDigital)}</div>
+    </div>
+  );
+};
+
+describe('ItemViewerContextV2 - Derived Canvas Data', () => {
+  it('should calculate currentCanvasIndex from canvas query param', () => {
+    const contextValue: ItemViewerContextV2Props = {
+      ...mockDefaultContext,
+      query: { canvas: 3, manifest: 1, page: 1, shouldScrollToCanvas: true, query: '' },
+      currentCanvasIndex: 2, // canvas=3 to index 2
+    };
+
+    render(
+      <ItemViewerContextV2.Provider value={contextValue}>
+        <ContextValueDisplay />
+      </ItemViewerContextV2.Provider>
+    );
+
+    expect(screen.getByTestId('currentCanvasIndex')).toHaveTextContent('2');
+  });
+
+  it('should handle mainImageService with empty string fallback', () => {
+    const contextValue: ItemViewerContextV2Props = {
+      ...mockDefaultContext,
+      currentCanvas: { id: 'canvas-1', imageServiceId: undefined },
+      mainImageService: { '@id': '' },
+    };
+
+    render(
+      <ItemViewerContextV2.Provider value={contextValue}>
+        <ContextValueDisplay />
+      </ItemViewerContextV2.Provider>
+    );
+
+    expect(screen.getByTestId('mainImageServiceId')).toHaveTextContent('none');
+  });
+
+  it('should detect multiple canvases correctly', () => {
+    const contextValue: ItemViewerContextV2Props = {
+      ...mockDefaultContext,
+      transformedManifest: {
+        canvases: [
+          { id: 'c1', label: 'Canvas 1' },
+          { id: 'c2', label: 'Canvas 2' },
+        ],
+      },
+      hasMultipleCanvases: true,
+    };
+
+    render(
+      <ItemViewerContextV2.Provider value={contextValue}>
+        <ContextValueDisplay />
+      </ItemViewerContextV2.Provider>
+    );
+
+    expect(screen.getByTestId('hasMultipleCanvases')).toHaveTextContent('true');
+  });
+
+  it('should correctly identify restricted canvas', () => {
+    const contextValue: ItemViewerContextV2Props = {
+      ...mockDefaultContext,
+      currentCanvas: {
+        id: 'canvas-1',
+        label: 'Canvas 1',
+        accessConditions: [{ type: 'RestrictedAccess' }],
+      },
+      isCurrentCanvasRestricted: true,
+    };
+
+    render(
+      <ItemViewerContextV2.Provider value={contextValue}>
+        <ContextValueDisplay />
+      </ItemViewerContextV2.Provider>
+    );
+
+    expect(screen.getByTestId('isCurrentCanvasRestricted')).toHaveTextContent('true');
+  });
+
+  it('should correctly calculate navigation booleans for first canvas', () => {
+    const contextValue: ItemViewerContextV2Props = {
+      ...mockDefaultContext,
+      currentCanvasIndex: 0,
+      transformedManifest: {
+        canvases: [
+          { id: 'c1', label: 'Canvas 1' },
+          { id: 'c2', label: 'Canvas 2' },
+          { id: 'c3', label: 'Canvas 3' },
+        ],
+      },
+      hasMultipleCanvases: true,
+      isFirstCanvas: true,
+      isLastCanvas: false,
+      canNavigateNext: true,
+      canNavigatePrevious: false,
+    };
+
+    render(
+      <ItemViewerContextV2.Provider value={contextValue}>
+        <ContextValueDisplay />
+      </ItemViewerContextV2.Provider>
+    );
+
+    expect(screen.getByTestId('isFirstCanvas')).toHaveTextContent('true');
+    expect(screen.getByTestId('isLastCanvas')).toHaveTextContent('false');
+    expect(screen.getByTestId('canNavigateNext')).toHaveTextContent('true');
+    expect(screen.getByTestId('canNavigatePrevious')).toHaveTextContent('false');
+  });
+
+  it('should correctly calculate navigation booleans for last canvas', () => {
+    const contextValue: ItemViewerContextV2Props = {
+      ...mockDefaultContext,
+      currentCanvasIndex: 2,
+      transformedManifest: {
+        canvases: [
+          { id: 'c1', label: 'Canvas 1' },
+          { id: 'c2', label: 'Canvas 2' },
+          { id: 'c3', label: 'Canvas 3' },
+        ],
+      },
+      hasMultipleCanvases: true,
+      isFirstCanvas: false,
+      isLastCanvas: true,
+      canNavigateNext: false,
+      canNavigatePrevious: true,
+    };
+
+    render(
+      <ItemViewerContextV2.Provider value={contextValue}>
+        <ContextValueDisplay />
+      </ItemViewerContextV2.Provider>
+    );
+
+    expect(screen.getByTestId('isFirstCanvas')).toHaveTextContent('false');
+    expect(screen.getByTestId('isLastCanvas')).toHaveTextContent('true');
+    expect(screen.getByTestId('canNavigateNext')).toHaveTextContent('false');
+    expect(screen.getByTestId('canNavigatePrevious')).toHaveTextContent('true');
+  });
+
+  it('should detect IIIF image service correctly', () => {
+    const contextValue: ItemViewerContextV2Props = {
+      ...mockDefaultContext,
+      currentCanvas: {
+        id: 'canvas-1',
+        label: 'Canvas 1',
+        imageServiceId: 'https://iiif.example.com/image/123',
+      },
+      hasIiifImageService: true,
+      isImageZoomable: true,
+    };
+
+    render(
+      <ItemViewerContextV2.Provider value={contextValue}>
+        <ContextValueDisplay />
+      </ItemViewerContextV2.Provider>
+    );
+
+    expect(screen.getByTestId('hasIiifImageService')).toHaveTextContent('true');
+    expect(screen.getByTestId('isImageZoomable')).toHaveTextContent('true');
+  });
+
+  it('should detect born digital works', () => {
+    const contextValue: ItemViewerContextV2Props = {
+      ...mockDefaultContext,
+      work: {
+        id: 'work-1',
+        title: 'Test Work',
+        production: [{ type: 'BornDigital' }],
+      },
+      isWorkBornDigital: true,
+    };
+
+    render(
+      <ItemViewerContextV2.Provider value={contextValue}>
+        <ContextValueDisplay />
+      </ItemViewerContextV2.Provider>
+    );
+
+    expect(screen.getByTestId('isWorkBornDigital')).toHaveTextContent('true');
+  });
+});
+```
+
+### 1.2 Mock Utilities with Types
+
+**File:** `content/webapp/contexts/ItemViewerContextV2/test-utils.ts`
+
+```typescript
+import type { ItemViewerContextV2Props } from './index';
+import type { TransformedManifest } from '@weco/content/types/manifest';
+import type { WorkBasic, Work } from '@weco/content/services/wellcome/catalogue/types';
+import type { CanvasRotatedImage } from '@weco/content/types/item-viewer';
+import type { UiTree } from '@weco/content/views/pages/works/work/work.types';
+
+export const mockDefaultContext: ItemViewerContextV2Props = {
+  // EXISTING PROPS (unchanged)
+  query: { 
+    canvas: 1, 
+    manifest: 1, 
+    page: 1, 
+    shouldScrollToCanvas: true, 
+    query: '' 
+  },
+  work: { 
+    id: 'test', 
+    title: 'Test Work',
+    alternativeTitles: [],
+    description: undefined,
+    languageId: undefined,
+    thumbnail: undefined,
+    referenceNumber: undefined,
+    productionDates: [],
+    archiveLabels: undefined,
+    cardLabels: [],
+    primaryContributorLabel: undefined,
+    notes: [],
+  } as WorkBasic & Pick<Work, 'description'>,
+  transformedManifest: undefined as TransformedManifest | undefined,
+  parentManifest: undefined,
+  searchResults: null,
+  setSearchResults: jest.fn(),
+  accessToken: undefined,
+  archiveTree: [] as UiTree,
+  setArchiveTree: jest.fn(),
+  canvasIndexById: {},
+  
+  // UI PROPS
+  viewerRef: { current: null },
+  mainAreaRef: { current: null },
+  mainAreaWidth: 1000,
+  mainAreaHeight: 500,
+  gridVisible: false,
+  setGridVisible: jest.fn(),
+  isFullscreen: false,
+  setIsFullscreen: jest.fn(),
+  isDesktopSidebarActive: true,
+  setIsDesktopSidebarActive: jest.fn(),
+  isMobileSidebarActive: false,
+  setIsMobileSidebarActive: jest.fn(),
+  showZoomed: false,
+  setShowZoomed: jest.fn(),
+  showFullscreenControl: false,
+  setShowFullscreenControl: jest.fn(),
+  showControls: false,
+  setShowControls: jest.fn(),
+  rotatedImages: [] as CanvasRotatedImage[],
+  setRotatedImages: jest.fn(),
+  isResizing: false,
+  errorHandler: undefined,
+  hasOnlyRenderableImages: false,
+  
+  // NEW: DERIVED CANVAS DATA (Phase 1)
+  currentCanvasIndex: 0,
+  currentCanvas: undefined,
+  mainImageService: { '@id': undefined },
+  urlTemplate: undefined,
+  imageUrl: undefined,
+  
+  // NEW: CANVAS-RELATED BOOLEANS
+  hasMultipleCanvases: false,
+  isCurrentCanvasRestricted: false,
+  isFirstCanvas: true,
+  isLastCanvas: true,
+  canNavigateNext: false,
+  canNavigatePrevious: false,
+  
+  // NEW: IMAGE SERVICE BOOLEANS
+  hasIiifImageService: false,
+  hasIiifImage: false,
+  shouldUseIiifImageLocation: false,
+  hasOnlyRenderableImages: false,
+  isImageZoomable: false,
+  
+  // NEW: WORK TYPE BOOLEANS
+  isWorkBornDigital: false,
+  hasVideoContent: false,
+  hasAudioContent: false,
+  
+  // NEW: DOWNLOAD BOOLEANS
+  hasDownloadOptions: false,
+  canDownloadCurrentCanvas: false,
+};
+```
+
+### 1.3 Component Integration Tests
+
+**File:** `content/webapp/views/pages/works/work/IIIFViewer/IIIFViewer.refactored.test.tsx`
+
+```typescript
+import { render, screen } from '@testing-library/react';
+import { RouterContext } from 'next/dist/shared/lib/router-context';
+import type { NextRouter } from 'next/router';
+
+import IIIFViewerRefactored from './IIIFViewer.refactored';
+import type { TransformedManifest } from '@weco/content/types/manifest';
+import type { WorkBasic, Work } from '@weco/content/services/wellcome/catalogue/types';
+
+const mockRouter: NextRouter = {
+  pathname: '/works/[workId]/items',
+  route: '/works/[workId]/items',
+  query: { workId: 'test-work', canvas: '1' },
+  asPath: '/works/test-work/items',
+  basePath: '',
+  isLocaleDomain: false,
+  push: jest.fn(),
+  replace: jest.fn(),
+  reload: jest.fn(),
+  back: jest.fn(),
+  forward: jest.fn(),
+  prefetch: jest.fn().mockResolvedValue(undefined),
+  beforePopState: jest.fn(),
+  events: {
+    on: jest.fn(),
+    off: jest.fn(),
+    emit: jest.fn(),
+  },
+  isFallback: false,
+  isReady: true,
+  isPreview: false,
+};
+
+const mockWork: WorkBasic & Pick<Work, 'description'> = {
+  id: 'test-work',
+  title: 'Test Work',
+  alternativeTitles: [],
+  production: [],
+  description: 'Test description',
+};
+
+const mockTransformedManifest: TransformedManifest = {
+  id: 'test-manifest',
+  label: 'Test Manifest',
+  canvases: [
+    { 
+      id: 'canvas-1', 
+      label: 'Canvas 1',
+      width: 1000,
+      height: 1000,
+    },
+  ],
+};
+
+describe('IIIFViewer.refactored - Context Integration', () => {
+  it('should provide currentCanvas to child components', () => {
+    render(
+      <RouterContext.Provider value={mockRouter}>
+        <IIIFViewerRefactored
+          work={mockWork}
+          transformedManifest={mockTransformedManifest}
+          searchResults={null}
+          setSearchResults={jest.fn()}
+        />
+      </RouterContext.Provider>
+    );
+
+    // Verify ViewerTopBar can access currentCanvas
+    expect(screen.queryByTestId('viewer-top-bar')).toBeInTheDocument();
+  });
+
+  it('should provide navigation booleans to components', () => {
+    const manifest: TransformedManifest = {
+      ...mockTransformedManifest,
+      canvases: [
+        { id: 'c1', label: 'Canvas 1', width: 1000, height: 1000 },
+        { id: 'c2', label: 'Canvas 2', width: 1000, height: 1000 },
+        { id: 'c3', label: 'Canvas 3', width: 1000, height: 1000 },
+      ],
+    };
+
+    render(
+      <RouterContext.Provider value={{ ...mockRouter, query: { workId: 'test', canvas: '1' } }}>
+        <IIIFViewerRefactored
+          work={mockWork}
+          transformedManifest={manifest}
+          searchResults={null}
+          setSearchResults={jest.fn()}
+        />
+      </RouterContext.Provider>
+    );
+
+    // First canvas - previous should be disabled
+    const prevButton = screen.queryByLabelText(/previous/i);
+    expect(prevButton).toBeDisabled();
+    
+    // Next should be enabled
+    const nextButton = screen.queryByLabelText(/next/i);
+    expect(nextButton).not.toBeDisabled();
+  });
+
+  it('should provide boolean flags for conditional rendering', () => {
+    const restrictedManifest: TransformedManifest = {
+      ...mockTransformedManifest,
+      canvases: [{
+        id: 'c1',
+        label: 'Canvas 1',
+        width: 1000,
+        height: 1000,
+        accessConditions: [{ type: 'RestrictedAccess' }],
+      }],
+    };
+
+    render(
+      <RouterContext.Provider value={mockRouter}>
+        <IIIFViewerRefactored
+          work={mockWork}
+          transformedManifest={restrictedManifest}
+          searchResults={null}
+          setSearchResults={jest.fn()}
+        />
+      </RouterContext.Provider>
+    );
+
+    // Verify restricted badge appears when isCurrentCanvasRestricted is true
+    expect(screen.queryByText(/restricted/i)).toBeInTheDocument();
+  });
+});
+```
+
+**File:** `content/webapp/views/pages/works/work/IIIFViewer/ViewerTopBar.refactored.test.tsx`
+
+```typescript
+import { render, screen } from '@testing-library/react';
+import type { FC } from 'react';
+
+import ItemViewerContextV2, { ItemViewerContextV2Props } from '@weco/content/contexts/ItemViewerContextV2';
+import { mockDefaultContext } from '@weco/content/contexts/ItemViewerContextV2/test-utils';
+
+import ViewerTopBarRefactored from './ViewerTopBar.refactored';
+import type { TransformedCanvas } from '@weco/content/types/manifest';
+
+describe('ViewerTopBar.refactored - Context Consumption', () => {
+  it('should use currentCanvas from context instead of calculating it', () => {
+    const contextValue: ItemViewerContextV2Props = {
+      ...mockDefaultContext,
+      currentCanvas: {
+        id: 'test-canvas',
+        label: 'Test Canvas',
+        width: 1000,
+        height: 1000,
+      } as TransformedCanvas,
+      hasDownloadOptions: true,
+    };
+
+    render(
+      <ItemViewerContextV2.Provider value={contextValue}>
+        <ViewerTopBarRefactored />
+      </ItemViewerContextV2.Provider>
+    );
+
+    // Should render download button because hasDownloadOptions is true
+    expect(screen.queryByRole('button', { name: /download/i })).toBeInTheDocument();
+  });
+
+  it('should use navigation booleans from context', () => {
+    const contextValue: ItemViewerContextV2Props = {
+      ...mockDefaultContext,
+      canNavigateNext: false,
+      canNavigatePrevious: true,
+      isLastCanvas: true,
+    };
+
+    render(
+      <ItemViewerContextV2.Provider value={contextValue}>
+        <ViewerTopBarRefactored />
+      </ItemViewerContextV2.Provider>
+    );
+
+    // Next button should be disabled when canNavigateNext is false
+    const nextButton = screen.queryByLabelText(/next/i);
+    expect(nextButton).toBeDisabled();
+
+    // Previous button should be enabled when canNavigatePrevious is true
+    const prevButton = screen.queryByLabelText(/previous/i);
+    expect(prevButton).not.toBeDisabled();
+  });
+
+  it('should use isCurrentCanvasRestricted from context', () => {
+    const contextValue: ItemViewerContextV2Props = {
+      ...mockDefaultContext,
+      isCurrentCanvasRestricted: true,
+      canDownloadCurrentCanvas: false,
+    };
+
+    render(
+      <ItemViewerContextV2.Provider value={contextValue}>
+        <ViewerTopBarRefactored />
+      </ItemViewerContextV2.Provider>
+    );
+
+    // Restricted badge should appear
+    expect(screen.queryByText(/restricted/i)).toBeInTheDocument();
+    
+    // Download should be disabled for restricted content
+    expect(screen.queryByRole('button', { name: /download/i })).toBeDisabled();
+  });
+});
+```
+
+## Manual Testing Checklist
+
+See [14-testing-strategy.md](./14-testing-strategy.md) for the complete manual testing checklist.
+
+---
+
+**Last Updated:** 1 April 2026

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -36,7 +36,7 @@ The RFC **should** include the following sections:
 
 ## RFC Listing
 
-_This is generated from the RFCs in this directory using `.script/create_table_summary.py`._
+_This is generated from the RFCs in this directory using `.scripts/create_table_summary.py`._
 
 | RFC ID | Summary | Next Line | Last Modified |
 |--------|---------|-----------|---------------|


### PR DESCRIPTION
## What does this change?
https://github.com/wellcomecollection/wellcomecollection.org/issues/9816

Originally in https://github.com/wellcomecollection/wellcomecollection.org/pull/12937 but David mentioned RFCs and I realised maybe this is where it should live instead. 

The Item Viewer has had a long life and is becoming more and more complex as we go. We need to consider
- Audio works
- Video works
- Image works
- PDF works
- Mixed media works
- Born Digital works

And then:
- No Javascript
- Restricted access works 
- Sensitive materials

And more!
So we thought it'd be nice to refactor it fully, focusing on readability, shared data (using context more for example), and maybe splitting the component further based on what should display/not. It's quite a complex piece of work and as it stands, because of the complexity of IIIF manifests, only Gareth feels comfortable building upon it. David and I thought we'd pair on the refactor to increase our knowledge and comfort level with it, and it starts with a plan. This plan was originally written by Claude after following some of my instructions. I then went through it, questioned it, rejigged it, added considerations extensively... I'm sure there is more to amend/consider/take on, so comments v welcome!

[Read it here](https://github.com/wellcomecollection/docs/blob/rfc-086-item-viewer/rfcs/086-item-viewer-refactor/README.md).