### PR TITLE
Exclude rfcs/ from Dependabot scanning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directories:
+      - "/rfcs/**"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "*"
+    open-pull-requests-limit: 0


### PR DESCRIPTION
Adds a .github/dependabot.yml that ignores all dependencies under rfcs/ - these are not running code and do not need to be maintained.

Also closed the two existing Dependabot PRs (#142, #144) that were open for rfcs/083-stable_identifiers.

Context: noticed by Raphaelle in [Slack](https://wellcome.slack.com/archives/C02ANCYL90E/p1778676888377009).