### PR TITLE
Exclude rfcs paths from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,11 @@
 version: 2
 updates:
   - package-ecosystem: "pip"
-    directories:
-      - "/rfcs/**"
+    directory: "/"
+    # Intentionally skip RFC experiments/docs to avoid dependency update PRs there.
+    exclude-paths:
+      - "rfcs/**"
     schedule:
       interval: "weekly"
     ignore:
       - dependency-name: "*"
-    open-pull-requests-limit: 0


### PR DESCRIPTION
## Summary

This updates Dependabot configuration so dependency updates do not come from RFC content.

## What changed

- Switched Dependabot from scanning only `rfcs/**` to scanning repo root (`/`) (Copilot seems to think we weren't scanning the whole thing, but last time he confirmed it still did 🤷‍♀️ )
- Added an explicit exclusion for `rfcs/**` using `exclude-paths` instead of restricting its PRs to 0. Apparently that only applies to package upgrades and not vulnerabilities. I assume from the fact it's not running any code that we're happy with it not updating anything.
- Added a short comment in the config to document intent.
- Removed redundant `open-pull-requests-limit: 0` for clarity.

## Why

The previous config unintentionally targeted RFC paths directly. This could still lead to confusion and unexpected Dependabot activity in `rfcs/`.

The new config makes intent explicit: RFC material is out of scope for Dependabot version update scanning.

## Validation

- Reviewed resulting config in `.github/dependabot.yml`

## Risk

Low. This is a config-only change that narrows Dependabot scanning scope for version updates.
