### PR TITLE
Ignore Claude Code worktree checkouts and local settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,9 @@ terraform.tfstate*
 .metals/
 .scala-build/
 .vscode/
+
+# Claude Code local state: worktree checkouts and personal settings.
+# .claude itself stays trackable in case shared settings are added later.
+.claude/worktrees/
+.claude/settings.local.json
+.git-worktrees/


### PR DESCRIPTION
Claude Code creates git worktrees under `.claude/worktrees/`, and this repo also accumulates them under `.git-worktrees/`. Neither was ignored. The only protection was a `.git/info/exclude` entry, which lives inside `.git/` and is never cloned, so it covered one machine and nobody else.

Each worktree contains a `.git` file, so a stray `git add -A` would write gitlink entries for them.

This ignores the local-state paths specifically rather than all of `.claude/`, so a shared `.claude/settings.json` stays trackable if we ever want one. Verified with `git check-ignore` that `.claude/settings.json` and `.claude/agents/` remain visible to git while the worktree and personal-settings paths do not.

Nothing under `.claude/` was already tracked, so no `git rm --cached` is needed.